### PR TITLE
Use BCryptHash instead of custom one-shot SHA

### DIFF
--- a/cng/sha.go
+++ b/cng/sha.go
@@ -13,47 +13,12 @@ import (
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
 )
 
-func writeSha(ctx bcrypt.HASH_HANDLE, p []byte) (err error) {
-	var n int
-	for n < len(p) && err == nil {
-		nn := lenU32(p[n:])
-		err = bcrypt.HashData(ctx, p[n:n+nn], 0)
-		n += nn
-	}
-	return err
-}
-
 func shaOneShot(id string, p, sum []byte) error {
 	h, err := loadSha(id, 0)
 	if err != nil {
 		return err
 	}
-	var buf []byte
-	// fbuf is a stack-allocated memory buffer big enough to hold all supported SHA types,
-	// tested on a Windows 11 10.0.22000 x64 machine.
-	// If the SHA object requires more memory, buf will be nil
-	// and bcrypt.CreateHash will internally heap-allocate the necessary memory.
-	// This is a performance optimization which boost one-shot SHAs ~10%.
-	var fbuf [512]byte
-	if h.objectLength <= uint32(len(fbuf)) {
-		buf = fbuf[:h.objectLength]
-	}
-	var ctx bcrypt.HASH_HANDLE
-	err = bcrypt.CreateHash(h.h, &ctx, buf, nil, 0)
-	if err != nil {
-		return err
-	}
-	defer bcrypt.DestroyHash(ctx)
-	err = writeSha(ctx, p)
-	if err != nil {
-		return err
-	}
-	err = bcrypt.FinishHash(ctx, sum, 0)
-	if err != nil {
-		return err
-	}
-	runtime.KeepAlive(fbuf)
-	return nil
+	return bcrypt.Hash(h.h, nil, p, sum)
 }
 
 func SHA1(p []byte) (sum [20]byte) {
@@ -105,10 +70,9 @@ func NewSHA512() hash.Hash {
 }
 
 type shaAlgorithm struct {
-	h            bcrypt.ALG_HANDLE
-	size         uint32
-	blockSize    uint32
-	objectLength uint32
+	h         bcrypt.ALG_HANDLE
+	size      uint32
+	blockSize uint32
 }
 
 func loadSha(id string, flags bcrypt.AlgorithmProviderFlags) (shaAlgorithm, error) {
@@ -121,11 +85,7 @@ func loadSha(id string, flags bcrypt.AlgorithmProviderFlags) (shaAlgorithm, erro
 		if err != nil {
 			return nil, err
 		}
-		objectLength, err := getUint32(bcrypt.HANDLE(h), bcrypt.OBJECT_LENGTH)
-		if err != nil {
-			return nil, err
-		}
-		return shaAlgorithm{h, size, blockSize, objectLength}, nil
+		return shaAlgorithm{h, size, blockSize}, nil
 	})
 	if err != nil {
 		return shaAlgorithm{}, err
@@ -184,7 +144,11 @@ func (h *shaXHash) Reset() {
 }
 
 func (h *shaXHash) Write(p []byte) (n int, err error) {
-	err = writeSha(h.ctx, p)
+	for n < len(p) && err == nil {
+		nn := lenU32(p[n:])
+		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
+		n += nn
+	}
 	if err != nil {
 		// hash.Hash interface mandates Write should never return an error.
 		panic(err)

--- a/cng/sha_test.go
+++ b/cng/sha_test.go
@@ -9,9 +9,7 @@ package cng_test
 import (
 	"bytes"
 	"hash"
-	"syscall"
 	"testing"
-	"unsafe"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -89,34 +87,7 @@ func TestSHA_OneShot(t *testing.T) {
 			if !bytes.Equal(got[:], want) {
 				t.Errorf("got:%x want:%x", got, want)
 			}
-			testSHAObjectLength(t, tt.id)
 		})
-	}
-}
-
-func testSHAObjectLength(t *testing.T, id string) {
-	pid, err := syscall.UTF16PtrFromString(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var h bcrypt.ALG_HANDLE
-	err = bcrypt.OpenAlgorithmProvider(&h, pid, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	name, err := syscall.UTF16PtrFromString(bcrypt.OBJECT_LENGTH)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var prop, discard uint32
-	err = bcrypt.GetProperty(bcrypt.HANDLE(h), name, (*[4]byte)(unsafe.Pointer(&prop))[:], &discard, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	const fbufSize = 512
-	if prop > fbufSize {
-		t.Fatalf("%s object length is %d, which is higher than %d, the current stack-allocated buffer size.\n"+
-			"Increase the buffer size passed to bcrypt.CreateHash in order to avoid allocating in one-shot SHA functions", id, prop, fbufSize)
 	}
 }
 

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -28,7 +28,6 @@ const (
 	CHAIN_MODE_CBC    = "ChainingModeCBC"
 	CHAIN_MODE_GCM    = "ChainingModeGCM"
 	KEY_LENGTHS       = "KeyLengths"
-	OBJECT_LENGTH     = "ObjectLength"
 	BLOCK_LENGTH      = "BlockLength"
 )
 
@@ -149,6 +148,7 @@ type RSAKEY_BLOB struct {
 
 // SHA and HMAC
 
+//sys	Hash(hAlgorithm ALG_HANDLE, pbSecret []byte, pbInput []byte, pbOutput []byte) (s error) = bcrypt.BCryptHash
 //sys	CreateHash(hAlgorithm ALG_HANDLE, phHash *HASH_HANDLE, pbHashObject []byte, pbSecret []byte, dwFlags uint32) (s error) = bcrypt.BCryptCreateHash
 //sys	DestroyHash(hHash HASH_HANDLE) (s error) = bcrypt.BCryptDestroyHash
 //sys   HashData(hHash HASH_HANDLE, pbInput []byte, dwFlags uint32) (s error) = bcrypt.BCryptHashData

--- a/internal/bcrypt/zsyscall_windows.go
+++ b/internal/bcrypt/zsyscall_windows.go
@@ -53,6 +53,7 @@ var (
 	procBCryptGenerateKeyPair        = modbcrypt.NewProc("BCryptGenerateKeyPair")
 	procBCryptGenerateSymmetricKey   = modbcrypt.NewProc("BCryptGenerateSymmetricKey")
 	procBCryptGetProperty            = modbcrypt.NewProc("BCryptGetProperty")
+	procBCryptHash                   = modbcrypt.NewProc("BCryptHash")
 	procBCryptHashData               = modbcrypt.NewProc("BCryptHashData")
 	procBCryptImportKeyPair          = modbcrypt.NewProc("BCryptImportKeyPair")
 	procBCryptOpenAlgorithmProvider  = modbcrypt.NewProc("BCryptOpenAlgorithmProvider")
@@ -227,6 +228,26 @@ func GetProperty(hObject HANDLE, pszProperty *uint16, pbOutput []byte, pcbResult
 		_p0 = &pbOutput[0]
 	}
 	r0, _, _ := syscall.Syscall6(procBCryptGetProperty.Addr(), 6, uintptr(hObject), uintptr(unsafe.Pointer(pszProperty)), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbOutput)), uintptr(unsafe.Pointer(pcbResult)), uintptr(dwFlags))
+	if r0 != 0 {
+		s = syscall.Errno(r0)
+	}
+	return
+}
+
+func Hash(hAlgorithm ALG_HANDLE, pbSecret []byte, pbInput []byte, pbOutput []byte) (s error) {
+	var _p0 *byte
+	if len(pbSecret) > 0 {
+		_p0 = &pbSecret[0]
+	}
+	var _p1 *byte
+	if len(pbInput) > 0 {
+		_p1 = &pbInput[0]
+	}
+	var _p2 *byte
+	if len(pbOutput) > 0 {
+		_p2 = &pbOutput[0]
+	}
+	r0, _, _ := syscall.Syscall9(procBCryptHash.Addr(), 7, uintptr(hAlgorithm), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbSecret)), uintptr(unsafe.Pointer(_p1)), uintptr(len(pbInput)), uintptr(unsafe.Pointer(_p2)), uintptr(len(pbOutput)), 0, 0)
 	if r0 != 0 {
 		s = syscall.Errno(r0)
 	}


### PR DESCRIPTION
Well, just right after merging #8 I found the [BCryptHash](https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcrypthash) function while I was looking for a way to export a hash state.

`BCryptHash` is the function to use when doing one-shot hashes, there is no need to have a custom slower implementation, as I tried in #8.

Using `BCryptHash` is ~20% faster than what we had before, which was carefully optimized with some unpleasant tricks:

```cmd
name       old time/op    new time/op     delta
SHA256-12     927ns ± 2%      721ns ± 7%  -22.22%  (p=0.000 n=8+10)

name       old speed      new speed       delta
SHA256-12  8.63MB/s ± 2%  11.12MB/s ± 7%  +28.83%  (p=0.000 n=8+10)

name       old alloc/op   new alloc/op    delta
SHA256-12     0.00B           0.00B          ~     (all equal)

name       old allocs/op  new allocs/op   delta
SHA256-12      0.00            0.00          ~     (all equal)
```
