### PR TITLE
Avoid allocating in string to []uint16 conversion

### DIFF
--- a/cng/cng.go
+++ b/cng/cng.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
-	"syscall"
 	"unsafe"
 
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -68,19 +67,18 @@ func loadOrStoreAlg(id string, flags bcrypt.AlgorithmProviderFlags, mode string,
 }
 
 func utf16PtrFromString(s string) *uint16 {
-	str, err := syscall.UTF16PtrFromString(s)
-	if err != nil {
-		panic(err)
-	}
-	return str
+	return &utf16FromString(s)[0]
 }
 
 func utf16FromString(s string) []uint16 {
-	str, err := syscall.UTF16FromString(s)
-	if err != nil {
-		panic(err)
+	a := make([]uint16, 0, 32)
+	for _, v := range s {
+		if v == 0 || v > 127 {
+			panic("utf16FromString only supports ASCII characters, got " + s)
+		}
+		a = append(a, uint16(v))
 	}
-	return str
+	return a
 }
 
 func setString(h bcrypt.HANDLE, name, val string) error {

--- a/cng/cng.go
+++ b/cng/cng.go
@@ -70,7 +70,12 @@ func utf16PtrFromString(s string) *uint16 {
 	return &utf16FromString(s)[0]
 }
 
+// utf16FromString converts the string using a stack-allocated slice of 32 bytes.
+// It should only be used to convert known BCrypt identifiers which only contains ASCII characters.
+// utf16FromString allocates if s is longer than 31 characters.
 func utf16FromString(s string) []uint16 {
+	// Once https://go.dev/issues/51896 lands and our support matrix allows it,
+	// we can replace part of this function by utf16.AppendRune
 	a := make([]uint16, 0, 32)
 	for _, v := range s {
 		if v == 0 || v > 127 {
@@ -78,6 +83,8 @@ func utf16FromString(s string) []uint16 {
 		}
 		a = append(a, uint16(v))
 	}
+	// Finish with a NULL byte.
+	a = append(a, 0)
 	return a
 }
 

--- a/cng/cng.go
+++ b/cng/cng.go
@@ -70,7 +70,7 @@ func utf16PtrFromString(s string) *uint16 {
 	return &utf16FromString(s)[0]
 }
 
-// utf16FromString converts the string using a stack-allocated slice of 32 bytes.
+// utf16FromString converts the string using a stack-allocated slice of 64 bytes.
 // It should only be used to convert known BCrypt identifiers which only contains ASCII characters.
 // utf16FromString allocates if s is longer than 31 characters.
 func utf16FromString(s string) []uint16 {

--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -8,7 +8,6 @@ package cng
 
 import (
 	"errors"
-	"math/big"
 	"runtime"
 	"unsafe"
 
@@ -214,10 +213,6 @@ func encodeECDSAKey(id string, bits uint32, X, Y, D BigInt) ([]byte, error) {
 		encode(D, hdr.KeySize)
 	}
 	return blob, nil
-}
-
-type ecdsaSignature struct {
-	R, S *big.Int
 }
 
 // SignECDSA signs a hash (which should be the result of hashing a larger message),

--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -71,7 +71,8 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	}
 	hdr := (*(*bcrypt.ECCKEY_BLOB)(unsafe.Pointer(&blob[0])))
 	if hdr.KeySize != (bits+7)/8 {
-		panic("crypto/ecdsa: exported key is corrupted")
+		err = errors.New("crypto/ecdsa: exported key is corrupted")
+		return
 	}
 	data := blob[sizeOfECCBlobHeader:]
 	consumeBigInt := func(size uint32) BigInt {

--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -75,8 +75,7 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	}
 	data := blob[sizeOfECCBlobHeader:]
 	consumeBigInt := func(size uint32) BigInt {
-		b := make(BigInt, size)
-		copy(b, data)
+		b := data[:size]
 		data = data[size:]
 		return b
 	}

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -73,8 +73,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	}
 	data := blob[sizeOfRSABlobHeader:]
 	consumeBigInt := func(size uint32) BigInt {
-		b := make(BigInt, size)
-		copy(b, data)
+		b := data[:size]
 		data = data[size:]
 		return b
 	}


### PR DESCRIPTION
This PR changes the way `string` is converted to `[]uint16` so it does not allocate. This conversion happens in multiple places, as Windows works with UTF18 but Go with UTF8.

We were previously using `syscall.UTF16FromString`, which always allocates, although it doesn't have to once https://github.com/golang/go/issues/51896 lands.

This change removes `syscall.UTF16FromString` calls and just converts the string using a good old for-loop with a stack-allocated slice of 32 bytes. We are not converting user-provided strings, just known BCrypt identifiers, which are short and only use ASCII characters, therefore the implementation does not need to account for runes that require two or more bytes.

These are the allocation improvements:

```go
name                 old allocs/op  new allocs/op   delta
SignECDSA-12             1.00 ± 0%       1.00 ± 0%     ~     (all equal)
VerifyECDSA-12           0.00            0.00          ~     (all equal)
GenerateKeyECDSA-12      6.00 ± 0%       4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
EncryptRSAPKCS1-12       1.00 ± 0%       1.00 ± 0%     ~     (all equal)
GenerateKeyRSA-12        11.0 ± 0%        9.0 ± 0%  -18.18%  (p=0.000 n=10+10)
Hash8Bytes-12            0.00            0.00          ~     (all equal)
SHA256-12                0.00            0.00          ~     (all equal)
```

Even though all benchmarked functions convert strings to utf16, only the ones that can't cache the result are improved.