### PR TITLE
Reuse backing array when creting BigInts

### DIFF
--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -75,8 +75,7 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	}
 	data := blob[sizeOfECCBlobHeader:]
 	consumeBigInt := func(size uint32) BigInt {
-		b := make(BigInt, size)
-		copy(b, data)
+		b := data[:size]
 		data = data[size:]
 		return b
 	}

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -73,8 +73,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	}
 	data := blob[sizeOfRSABlobHeader:]
 	consumeBigInt := func(size uint32) BigInt {
-		b := make(BigInt, size)
-		copy(b, data)
+		b := data[:size]
 		data = data[size:]
 		return b
 	}


### PR DESCRIPTION
This PR reduce to the bare minimum the allocations in `GenerateKeyRSA` and `GenerateKeyECDSA` by reusing the same backing array when creating each `BigInt`, instead of allocating a new byte slice each time.

The trick is that `BigInt` is defined to have the same representation as a CNG big integer, so we can create new `BigInt`s by just slicing the blob returned by `BCryptExportKey`. Go garbage collector is smart enough to keep the backing array live meanwhile there is a slice referencing it.

These are the allocation improvements:

```
name                 old allocs/op  new allocs/op  delta
SignECDSA-12             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
VerifyECDSA-12           0.00           0.00          ~     (all equal)
GenerateKeyECDSA-12      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)
EncryptRSAPKCS1-12       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
GenerateKeyRSA-12        9.00 ± 0%      1.00 ± 0%  -88.89%  (p=0.000 n=10+10)
Hash8Bytes-12            0.00           0.00          ~     (all equal)
SHA256-12                0.00           0.00          ~     (all equal)
```