### PR TITLE
VerifyECDSA to accept BigInts shorter than the key size

### DIFF
--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -238,13 +238,14 @@ func SignECDSA(priv *PrivateKeyECDSA, hash []byte) (r, s BigInt, err error) {
 // VerifyECDSA verifies the signature in r, s of hash using the public key, pub.
 func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s BigInt) bool {
 	// r and s might be shorter than size
-	// if the original big number contained leading zeros.
+	// if the original big number contained leading zeros,
+	// but they must not be longer than the public key size.
 	if len(r) > pub.size || len(s) > pub.size {
 		return false
 	}
 	sig := make([]byte, 0, pub.size*2)
-	prependZeros := func(l int) {
-		if zeros := pub.size - l; zeros > 0 {
+	prependZeros := func(nonZeroBytes int) {
+		if zeros := pub.size - nonZeroBytes; zeros > 0 {
 			sig = append(sig, make([]byte, zeros)...)
 		}
 	}

--- a/cng/ecdsa_test.go
+++ b/cng/ecdsa_test.go
@@ -20,9 +20,9 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
 		name  string
 		curve elliptic.Curve
 	}{
+		{"P521", elliptic.P521()},
 		{"P256", elliptic.P256()},
 		{"P384", elliptic.P384()},
-		{"P521", elliptic.P521()},
 	}
 	for _, test := range tests {
 		curve := test.curve
@@ -68,7 +68,8 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 	if err != nil {
 		t.Fatalf("SignECDSA error: %s", err)
 	}
-	if !cng.VerifyECDSA(pub, hashed, r, s) {
+	// Exercise bbig roundtrip.
+	if !cng.VerifyECDSA(pub, hashed, bbig.Enc(bbig.Dec(r)), bbig.Enc(bbig.Dec(s))) {
 		t.Errorf("Verify failed")
 	}
 	hashed[0] ^= 0xff

--- a/cng/ecdsa_test.go
+++ b/cng/ecdsa_test.go
@@ -20,9 +20,9 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
 		name  string
 		curve elliptic.Curve
 	}{
-		{"P521", elliptic.P521()},
 		{"P256", elliptic.P256()},
 		{"P384", elliptic.P384()},
+		{"P521", elliptic.P521()},
 	}
 	for _, test := range tests {
 		curve := test.curve


### PR DESCRIPTION
`VerifyECDSA` fails if the supplied big numbers are shorter than the expected key size. This can happen because the conversion done by `bbig.Enc` removes all trailing zeros from the big number.

Found while integrating this library into the Go tree.