### PR TITLE
HMAC should produce correct hashes when key is empty

### DIFF
--- a/cng/hmac.go
+++ b/cng/hmac.go
@@ -50,6 +50,8 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		// allow keys longer than math.MaxUint32 bytes.
 		ch.Write(key)
 		key = ch.Sum(nil)
+	} else if key == nil {
+		key = []byte{}
 	}
 	return newSHAX(id, key)
 }

--- a/cng/hmac.go
+++ b/cng/hmac.go
@@ -50,8 +50,6 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		// allow keys longer than math.MaxUint32 bytes.
 		ch.Write(key)
 		key = ch.Sum(nil)
-	} else if key == nil {
-		key = []byte{}
 	}
-	return newSHAX(id, key)
+	return newSHAX(id, bcrypt.ALG_HANDLE_HMAC_FLAG, key)
 }

--- a/cng/hmac_test.go
+++ b/cng/hmac_test.go
@@ -8,9 +8,34 @@ package cng
 
 import (
 	"bytes"
+	"fmt"
 	"hash"
 	"testing"
 )
+
+func TestHMAC_EmptyKey(t *testing.T) {
+	const payload = "message"
+	var tests = []struct {
+		name string
+		fn   func() hash.Hash
+		out  string
+	}{
+		{"sha1", NewSHA1, "d5d1ed05121417247616cfc8378f360a39da7cfa"},
+		{"sha256", NewSHA256, "eb08c1f56d5ddee07f7bdf80468083da06b64cf4fac64fe3a90883df5feacae4"},
+		{"sha384", NewSHA384, "a1302a8028a419bb834bfae53c5e98ab48e07aed9ef8b980a821df28685902003746ade315072edd8ce009a1d23705ec"},
+		{"sha512", NewSHA512, "08fce52f6395d59c2a3fb8abb281d74ad6f112b9a9c787bcea290d94dadbc82b2ca3e5e12bf2277c7fedbb0154d5493e41bb7459f63c8e39554ea3651b812492"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHMAC(tt.fn, nil)
+			h.Write([]byte(payload))
+			sum := fmt.Sprintf("%x", h.Sum(nil))
+			if sum != tt.out {
+				t.Errorf("have %s want %s\n", sum, tt.out)
+			}
+		})
+	}
+}
 
 func TestHMAC(t *testing.T) {
 	key := []byte{1, 2, 3}

--- a/cng/sha.go
+++ b/cng/sha.go
@@ -51,22 +51,22 @@ func SHA512(p []byte) (sum [64]byte) {
 
 // NewSHA1 returns a new SHA1 hash.
 func NewSHA1() hash.Hash {
-	return newSHAX(bcrypt.SHA1_ALGORITHM, nil)
+	return newSHAX(bcrypt.SHA1_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
 }
 
 // NewSHA256 returns a new SHA256 hash.
 func NewSHA256() hash.Hash {
-	return newSHAX(bcrypt.SHA256_ALGORITHM, nil)
+	return newSHAX(bcrypt.SHA256_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
 }
 
 // NewSHA384 returns a new SHA384 hash.
 func NewSHA384() hash.Hash {
-	return newSHAX(bcrypt.SHA384_ALGORITHM, nil)
+	return newSHAX(bcrypt.SHA384_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
 }
 
 // NewSHA512 returns a new SHA512 hash.
 func NewSHA512() hash.Hash {
-	return newSHAX(bcrypt.SHA512_ALGORITHM, nil)
+	return newSHAX(bcrypt.SHA512_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
 }
 
 type shaAlgorithm struct {
@@ -102,12 +102,7 @@ type shaXHash struct {
 	key       []byte
 }
 
-func newSHAX(id string, key []byte) *shaXHash {
-	var flag bcrypt.AlgorithmProviderFlags
-	if key != nil {
-		// HMAC can pass an empty key to newSHAX.
-		flag = bcrypt.ALG_HANDLE_HMAC_FLAG
-	}
+func newSHAX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *shaXHash {
 	h, err := loadSha(id, flag)
 	if err != nil {
 		panic(err)

--- a/cng/sha.go
+++ b/cng/sha.go
@@ -104,7 +104,8 @@ type shaXHash struct {
 
 func newSHAX(id string, key []byte) *shaXHash {
 	var flag bcrypt.AlgorithmProviderFlags
-	if len(key) > 0 {
+	if key != nil {
+		// HMAC can pass an empty key to newSHAX.
 		flag = bcrypt.ALG_HANDLE_HMAC_FLAG
 	}
 	h, err := loadSha(id, flag)


### PR DESCRIPTION
We should set `bcrypt.ALG_HANDLE_HMAC_FLAG` when creating a new hash to be used as an HMAC, even if the key is empty.