### PR TITLE
Check RSA key length

### DIFF
--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -22,15 +22,13 @@ type ecdsaAlgorithm struct {
 }
 
 func loadEcdsa(id string) (h ecdsaAlgorithm, err error) {
-	if v, ok := algCache.Load(id); ok {
-		return v.(ecdsaAlgorithm), nil
-	}
-	err = bcrypt.OpenAlgorithmProvider(&h.handle, utf16PtrFromString(id), nil, bcrypt.ALG_NONE_FLAG)
+	v, err := loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+		return ecdsaAlgorithm{h}, nil
+	})
 	if err != nil {
-		return
+		return ecdsaAlgorithm{}, err
 	}
-	algCache.Store(id, h)
-	return
+	return v.(ecdsaAlgorithm), nil
 }
 
 const sizeOfECCBlobHeader = uint32(unsafe.Sizeof(bcrypt.ECCKEY_BLOB{}))

--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -34,6 +34,13 @@ func newRSAKey(t *testing.T, size int) (*cng.PrivateKeyRSA, *cng.PublicKeyRSA) {
 	return priv, pub
 }
 
+func TestGenerateKeyRSA_InvalidLength(t *testing.T) {
+	_, _, _, _, _, _, _, _, err := cng.GenerateKeyRSA(2)
+	if err == nil {
+		t.Error("error expected")
+	}
+}
+
 func TestRSAKeyGeneration(t *testing.T) {
 	for _, size := range []int{2048, 3072} {
 		t.Run(strconv.Itoa(size), func(t *testing.T) {


### PR DESCRIPTION
This PR adds a new check to `GenerateKeyRSA`, `NewPublicKeyRSA` and `NewPrivateKeyRSA` that verifies the key length is supported by CNG. The list of supported key lengths can be found dynamically by querying the [BCRYPT_KEY_LENGTHS_STRUCT](https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_key_lengths_struct) property.

CNG already errors out when signing and encrypting payloads using an unsupported RSA key, but the message is cryptic and it is reported long after the key has been created, which make it difficult to debug. We better error early.

Found while integrating this backend into Go. Lost a couple of hours debugging.