### PR TITLE
Account for RSA-PSS salt length special cases

### DIFF
--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -318,7 +318,14 @@ func newPSS_PADDING_INFO(h crypto.Hash, saltLen int) (info bcrypt.PSS_PADDING_IN
 		return info, errors.New("crypto/rsa: unsupported hash function")
 	}
 	info.AlgId = utf16PtrFromString(hashID)
-	info.Salt = uint32(saltLen)
+	switch saltLen {
+	case -1: // rsa.PSSSaltLengthEqualsHash
+		info.Salt = uint32(h.Size())
+	case 0: // rsa.PSSSaltLengthAuto
+		err = errors.New("crypto/rsa: rsa.PSSSaltLengthAuto not supported")
+	default:
+		info.Salt = uint32(saltLen)
+	}
 	return
 }
 

--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -157,11 +157,26 @@ func TestSignVerifyRSAPSS(t *testing.T) {
 	priv, pub := newRSAKey(t, 2048)
 	sha256.Write([]byte("testing"))
 	hashed := sha256.Sum(nil)
-	signed, err := cng.SignRSAPSS(priv, crypto.SHA256, hashed, 0)
+	signed, err := cng.SignRSAPSS(priv, crypto.SHA256, hashed, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cng.VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, 0)
+	err = cng.VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignVerifyRSAPSS_PSSSaltLengthEqualsHash(t *testing.T) {
+	sha256 := cng.NewSHA256()
+	priv, pub := newRSAKey(t, 2048)
+	sha256.Write([]byte("testing"))
+	hashed := sha256.Sum(nil)
+	signed, err := cng.SignRSAPSS(priv, crypto.SHA256, hashed, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cng.VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, -1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR teaches `SignRSAPSS` and `VerifyRSAPSS` to understand Go salt length special cases: `rsa.PSSSaltLengthAuto` and `rsa.PSSSaltLengthEqualsHash`.

Unfortunately, CNG does not support them out-of-the-box.

- `rsa.PSSSaltLengthEqualsHash` is straightforward to implement, it just means the salt length should be equal to the hash length.

- `rsa.PSSSaltLengthAuto` requires decoding and understanding the bits of the signature, thus out of our scope. I would rather error out and fallback to Go crypto when `rsa.PSSSaltLengthAuto` is used. Added to #4 so we don't miss this limitation in the documentation.