### PR TITLE
Implement SHAs marshal methods

### DIFF
--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -32,6 +32,7 @@ const (
 	CHAIN_MODE_GCM    = "ChainingModeGCM"
 	KEY_LENGTHS       = "KeyLengths"
 	BLOCK_LENGTH      = "BlockLength"
+	OBJECT_LENGTH     = "ObjectLength"
 )
 
 const (


### PR DESCRIPTION
This PR extend our SHA types to also implement `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler` interfaces.

The caveat is that we don't know how to decode a CNG Hash internal state, so we can't map it to the scheme used in stdlib, openssl and boring hashes. This means that a marshaled CNG state can't be persisted in disk and loaded later on using a non-CNG binary, and vice versa.

I've been reluctant to add these methods during the implementation of this library due to the compatibility issue, but they are being used in the TLS1.3 implementation and it is difficult to work-around its use, so at the end I had implement them.

This change adds a new allocation to the sha creation, but this is normally amortized by reusing the same hash instance and calling `Reset()` on every new use.