### PR TITLE
Implement shaXHash.Clone()

### DIFF
--- a/cng/sha.go
+++ b/cng/sha.go
@@ -127,6 +127,23 @@ func (h *shaXHash) finalize() {
 	}
 }
 
+func (h *shaXHash) Clone() (hash.Hash, error) {
+	h2 := &shaXHash{
+		h:         h.h,
+		size:      h.size,
+		blockSize: h.blockSize,
+		buf:       make([]byte, len(h.buf)),
+		key:       make([]byte, len(h.key)),
+	}
+	copy(h2.key, h.key)
+	err := bcrypt.DuplicateHash(h.ctx, &h2.ctx, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	runtime.KeepAlive(h)
+	return h2, nil
+}
+
 func (h *shaXHash) Reset() {
 	if h.ctx != 0 {
 		bcrypt.DestroyHash(h.ctx)

--- a/cng/sha_test.go
+++ b/cng/sha_test.go
@@ -45,6 +45,15 @@ func TestSha(t *testing.T) {
 				t.Error("Write didn't change internal hash state")
 			}
 
+			h2, err := h.(interface{ Clone() (hash.Hash, error) }).Clone()
+			if err != nil {
+				t.Fatal(err)
+			}
+			h.Write(msg)
+			h2.Write(msg)
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", tt.name, msg, actual, actual2)
+			}
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {


### PR DESCRIPTION
⚠️ This PR supersedes #20
 
This PR adds a Clone method to all supported SHAs. It is necessary because some standard library Go crypto logic relies on the hash to be cloneable, more specifically the TLS 1.3 server handshake: https://github.com/golang/go/blob/de8101d21bcf5f1097bcfaf3a1b55820ba70dce9/src/crypto/tls/handshake_server_tls13.go#L329.

The problem is that Go TLS 1.3 clones the hash via the binary marshal interface, and CNG does not support it. The `Clone()` method is a workaround for supporting TLS 1.3 without providing the binary marshalling interface. 

It will be used like this:

```go
func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
  // Recreate the interface to avoid importing encoding.
  type binaryMarshaler interface {
    MarshalBinary() (data []byte, err error)
    UnmarshalBinary(data []byte) error
  }
  marshaler, ok := in.(binaryMarshaler)
  if !ok {
    // CNGCrypto hashes do not implement the binaryMarshaler interface,
    // but do implement the Clone method.
    if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
       if out, err := cloner.Clone(); err != nil {
         return out
       }
    }
    return nil
  }
  ...
}
```