### PR TITLE
Fix panic when AES-GSM additional data is empty

### DIFF
--- a/cng/aes_test.go
+++ b/cng/aes_test.go
@@ -59,6 +59,15 @@ func TestSealAndOpen(t *testing.T) {
 	if !bytes.Equal(decrypted, plainText) {
 		t.Errorf("unexpected decrypted result\ngot: %#v\nexp: %#v", decrypted, plainText)
 	}
+	// Test with no additional data.
+	sealed = gcm.Seal(nil, nonce, plainText, []byte{})
+	decrypted, err = gcm.Open(nil, nonce, sealed, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(decrypted, plainText) {
+		t.Errorf("unexpected decrypted result\ngot: %#v\nexp: %#v", decrypted, plainText)
+	}
 }
 
 func TestSealAndOpenTLS(t *testing.T) {

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -111,7 +111,7 @@ type AUTHENTICATED_CIPHER_MODE_INFO struct {
 
 func NewAUTHENTICATED_CIPHER_MODE_INFO(nonce, additionalData, tag []byte) *AUTHENTICATED_CIPHER_MODE_INFO {
 	var aad *byte
-	if additionalData != nil {
+	if len(additionalData) > 0 {
 		aad = &additionalData[0]
 	}
 	info := AUTHENTICATED_CIPHER_MODE_INFO{


### PR DESCRIPTION
This PR fixes a bug in AES-GCM `Seal()` method causing a panic when the additional data was empty. The additional data parameter is optional, so we should not panic.

Found while integrating the CNG backend into the Go tree.

 