### PR TITLE
Fix handling of empty buffers in BCryptEncrypt

### DIFF
--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -72,6 +72,24 @@ func TestEncryptDecryptOAEP(t *testing.T) {
 	}
 }
 
+func TestEncryptDecryptOAEP_Empty(t *testing.T) {
+	sha256 := cng.NewSHA256()
+	msg := []byte("")
+	label := []byte("ho!")
+	priv, pub := newRSAKey(t, 2048)
+	enc, err := cng.EncryptRSAOAEP(sha256, pub, msg, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := cng.DecryptRSAOAEP(sha256, priv, enc, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dec, msg) {
+		t.Errorf("got:%x want:%x", dec, msg)
+	}
+}
+
 func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
 	sha256 := cng.NewSHA256()
 	msg := []byte("hi!")

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -167,8 +167,8 @@ func Encrypt(hKey KEY_HANDLE, plaintext []byte, pPaddingInfo unsafe.Pointer, pbI
 		pInput = &plaintext[0]
 	} else {
 		// BCryptEncrypt does not support nil plaintext.
-		// Allocate an zero byte here just to make CNG happy.
-		// It wont be encrypted anyway because the plaintext length is zero.
+		// Allocate a zero byte here just to make CNG happy.
+		// It won't be encrypted anyway because the plaintext length is zero.
 		pInput = new(byte)
 	}
 	return _Encrypt(hKey, pInput, uint32(len(plaintext)), pPaddingInfo, pbIV, pbOutput, pcbResult, dwFlags)

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -161,6 +161,19 @@ type ECCKEY_BLOB struct {
 	KeySize uint32
 }
 
+func Encrypt(hKey KEY_HANDLE, plaintext []byte, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) {
+	var pInput *byte
+	if len(plaintext) > 0 {
+		pInput = &plaintext[0]
+	} else {
+		// BCryptEncrypt does not support nil plaintext.
+		// Allocate an zero byte here just to make CNG happy.
+		// It wont be encrypted anyway because the plaintext length is zero.
+		pInput = new(byte)
+	}
+	return _Encrypt(hKey, pInput, uint32(len(plaintext)), pPaddingInfo, pbIV, pbOutput, pcbResult, dwFlags)
+}
+
 //sys	GetFipsAlgorithmMode(enabled *bool) (s error) = bcrypt.BCryptGetFipsAlgorithmMode
 //sys	SetProperty(hObject HANDLE, pszProperty *uint16, pbInput []byte, dwFlags uint32) (s error) = bcrypt.BCryptSetProperty
 //sys	GetProperty(hObject HANDLE, pszProperty *uint16, pbOutput []byte, pcbResult *uint32, dwFlags uint32) (s error) = bcrypt.BCryptGetProperty
@@ -188,7 +201,7 @@ type ECCKEY_BLOB struct {
 //sys   ImportKeyPair (hAlgorithm ALG_HANDLE, hImportKey KEY_HANDLE, pszBlobType *uint16, phKey *KEY_HANDLE, pbInput []byte, dwFlags uint32) (s error) = bcrypt.BCryptImportKeyPair
 //sys   ExportKey(hKey KEY_HANDLE, hExportKey KEY_HANDLE, pszBlobType *uint16, pbOutput []byte, pcbResult *uint32, dwFlags uint32) (s error) = bcrypt.BCryptExportKey
 //sys   DestroyKey(hKey KEY_HANDLE) (s error) = bcrypt.BCryptDestroyKey
-//sys   Encrypt(hKey KEY_HANDLE, pbInput []byte, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) = bcrypt.BCryptEncrypt
+//sys   _Encrypt(hKey KEY_HANDLE, pbInput *byte, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) = bcrypt.BCryptEncrypt
 //sys   Decrypt(hKey KEY_HANDLE, pbInput []byte, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) = bcrypt.BCryptDecrypt
 //sys   SignHash (hKey KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbInput []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) = bcrypt.BCryptSignHash
 //sys   VerifySignature(hKey KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHash []byte, pbSignature []byte, dwFlags PadMode) (s error) = bcrypt.BCryptVerifySignature

--- a/internal/bcrypt/zsyscall_windows.go
+++ b/internal/bcrypt/zsyscall_windows.go
@@ -135,20 +135,16 @@ func DuplicateHash(hHash HASH_HANDLE, phNewHash *HASH_HANDLE, pbHashObject []byt
 	return
 }
 
-func Encrypt(hKey KEY_HANDLE, pbInput []byte, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) {
+func _Encrypt(hKey KEY_HANDLE, pbInput *byte, cbInput uint32, pPaddingInfo unsafe.Pointer, pbIV []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) {
 	var _p0 *byte
-	if len(pbInput) > 0 {
-		_p0 = &pbInput[0]
+	if len(pbIV) > 0 {
+		_p0 = &pbIV[0]
 	}
 	var _p1 *byte
-	if len(pbIV) > 0 {
-		_p1 = &pbIV[0]
-	}
-	var _p2 *byte
 	if len(pbOutput) > 0 {
-		_p2 = &pbOutput[0]
+		_p1 = &pbOutput[0]
 	}
-	r0, _, _ := syscall.Syscall12(procBCryptEncrypt.Addr(), 10, uintptr(hKey), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbInput)), uintptr(pPaddingInfo), uintptr(unsafe.Pointer(_p1)), uintptr(len(pbIV)), uintptr(unsafe.Pointer(_p2)), uintptr(len(pbOutput)), uintptr(unsafe.Pointer(pcbResult)), uintptr(dwFlags), 0, 0)
+	r0, _, _ := syscall.Syscall12(procBCryptEncrypt.Addr(), 10, uintptr(hKey), uintptr(unsafe.Pointer(pbInput)), uintptr(cbInput), uintptr(pPaddingInfo), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbIV)), uintptr(unsafe.Pointer(_p1)), uintptr(len(pbOutput)), uintptr(unsafe.Pointer(pcbResult)), uintptr(dwFlags), 0, 0)
 	if r0 != 0 {
 		s = syscall.Errno(r0)
 	}


### PR DESCRIPTION
This PR adds support to encrypt empty buffers so we don't have to fallback to Go crypto.

I initially thought there was no easy way to do so, but after doing some GitHub archeology I found this PR https://github.com/dotnet/pinvoke/pull/180, which fixes the empty buffer situation by replacing the empty plaintext buffer with a dummy byte.

This dummy byte does not affect the encryption result because we also pass the plaintext length to `BCryptEncrypt`, which is zero. 