### PR TITLE
Hardcode golang.org/x/sys version in mksyscall.go

### DIFF
--- a/cmd/mksyscall/main.go
+++ b/cmd/mksyscall/main.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 )
 
+const mkwinsyscallVersion = "b874c991c1a5"
+
 const description = `
 Example:
 
@@ -65,7 +67,7 @@ func install(goTool string) {
 	// mkwinsyscall is hardcoded here instead of adding it to go.mod so
 	// it doesn't appear in go.sum, which will reduce the likelihood
 	// of having patch conflicts when vendoring go-crypto-winnative.
-	args := []string{"install", "golang.org/x/sys/windows/mkwinsyscall@b874c991c1a5"}
+	args := []string{"install", "golang.org/x/sys/windows/mkwinsyscall@" + mkwinsyscallVersion}
 	cmd := exec.Command(goTool, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/mksyscall/main.go
+++ b/cmd/mksyscall/main.go
@@ -62,7 +62,10 @@ func main() {
 // install makes sure mkwinsyscall can be called by
 // running go install golang.org/x/sys/windows/mkwinsyscall.
 func install(goTool string) {
-	args := []string{"install", "golang.org/x/sys/windows/mkwinsyscall"}
+	// mkwinsyscall is hardcoded here instead of adding it to go.mod so
+	// it doesn't appear in go.sum, which will reduce the likelihood
+	// of having patch conflicts when vendoring go-crypto-winnative.
+	args := []string{"install", "golang.org/x/sys/windows/mkwinsyscall@b874c991c1a5"}
 	cmd := exec.Command(goTool, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/microsoft/go-crypto-winnative
 
 go 1.16
-
-require golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
-golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tools.go
+++ b/tools.go
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-//go:build tools
-// +build tools
-
-package cng
-
-import _ "golang.org/x/sys/windows/mkwinsyscall"


### PR DESCRIPTION
I recently had to resolve a patch conflict while syncing the Microsoft Go fork with upstream because upstream changed `src/go.sum` and `go-crypto-winnative` is adding a line in that file.

This PR removes our `go.sum` file so it does not end up in the patch file. It works because the only entry in our `go.sum` is a development dependency only used when running `go generate ./...`, therefore having it in `go.sum` is nice to have but not required, and in this case is doing more harm than good.