### PR TITLE
Free cloned SHA context when it is garbage collected

### DIFF
--- a/cng/sha.go
+++ b/cng/sha.go
@@ -140,6 +140,7 @@ func (h *shaXHash) Clone() (hash.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
+	runtime.SetFinalizer(h2, (*shaXHash).finalize)
 	runtime.KeepAlive(h)
 	return h2, nil
 }


### PR DESCRIPTION
This PR fixes a memory leak on `shaXHash.Clone()`. The returned instance owns a `bcrypt.HASH_HANDLE` allocated using `bcrypt.DuplicateHash`. The logic to free the context memory resides in `shaXHash.finalize`, which should be called automatically when the sha instance is garbage collected.

The problem is that Go doesn't know it has to call `shaXHash.finalize`, we have to instruct it by calling runtime.SetFinalizer(h, (*shaXHash).finalize) just after instantiating the sha. And we are not doing that.