### PR TITLE
Fix RSA size calculation and support nil RSA precomputed values 

### DIFF
--- a/cng/big.go
+++ b/cng/big.go
@@ -2,13 +2,29 @@
 // Licensed under the MIT License.
 package cng
 
+import "math/bits"
+
 // This file does not have build constraints to
 // facilitate using BigInt in Go crypto.
 // Go crypto references BigInt unconditionally,
 // even if it is not finally used.
 
-// A BigInt is the big-endian bytes from a math/big BigInt.
+// A BigInt is the big-endian bytes from a math/big BigInt,
+// which are normalized to remove any leading 0 byte.
 // Windows BCrypt accepts this specific data format.
 // This definition allows us to avoid importing math/big.
 // Conversion between BigInt and *big.Int is in cng/bbig.
 type BigInt []byte
+
+const _S = bits.UintSize / 8 // word size in bytes
+
+// Length of x in bits.
+func (x BigInt) bitLen() int {
+	if len(x) == 0 {
+		return 0
+	}
+	// x is normalized, so the length in bits is
+	// the length in bits of x minus one byte (_S),
+	// plus the minimum number of bits to represent the first byte.
+	return (len(x)-1)*_S + bits.Len(uint(x[0]))
+}

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -163,7 +163,7 @@ func encodeRSAKey(N, E, D, P, Q, Dp, Dq, Qinv BigInt) ([]byte, error) {
 		hdr.Magic = bcrypt.RSAPUBLIC_MAGIC
 		blob = make([]byte, sizeOfRSABlobHeader+hdr.PublicExpSize+hdr.ModulusSize)
 	} else {
-		if P == nil || Q == nil || Dp == nil || Dq == nil || Qinv == nil {
+		if P == nil || Q == nil {
 			// This case can happen when the key has been generated with more than 2 primes.
 			// CNG only supports 2-prime keys.
 			return nil, errors.New("crypto/rsa: unsupported private key")

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -83,6 +83,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 
 type PublicKeyRSA struct {
 	hkey bcrypt.KEY_HANDLE
+	bits uint32
 }
 
 func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
@@ -97,7 +98,7 @@ func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
 	if err != nil {
 		return nil, err
 	}
-	k := &PublicKeyRSA{hkey}
+	k := &PublicKeyRSA{hkey, uint32(N.bitLen())}
 	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
 	return k, nil
 }
@@ -108,6 +109,7 @@ func (k *PublicKeyRSA) finalize() {
 
 type PrivateKeyRSA struct {
 	hkey bcrypt.KEY_HANDLE
+	bits uint32
 }
 
 func (k *PrivateKeyRSA) finalize() {
@@ -126,7 +128,7 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error
 	if err != nil {
 		return nil, err
 	}
-	k := &PrivateKeyRSA{hkey}
+	k := &PrivateKeyRSA{hkey, uint32(N.bitLen())}
 	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
 	return k, nil
 }
@@ -218,7 +220,7 @@ func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 
 func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
 	defer runtime.KeepAlive(priv)
-	info, err := newPSS_PADDING_INFO(priv.hkey, h, saltLen, true)
+	info, err := newPSS_PADDING_INFO(h, priv.bits, saltLen, true)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +229,7 @@ func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) 
 
 func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 	defer runtime.KeepAlive(pub)
-	info, err := newPSS_PADDING_INFO(pub.hkey, h, saltLen, false)
+	info, err := newPSS_PADDING_INFO(h, pub.bits, saltLen, false)
 	if err != nil {
 		return err
 	}
@@ -308,7 +310,7 @@ func keyVerify(pkey bcrypt.KEY_HANDLE, info unsafe.Pointer, hashed, sig []byte, 
 	return bcrypt.VerifySignature(pkey, info, hashed, sig, flags)
 }
 
-func newPSS_PADDING_INFO(pkey bcrypt.KEY_HANDLE, h crypto.Hash, saltLen int, sign bool) (info bcrypt.PSS_PADDING_INFO, err error) {
+func newPSS_PADDING_INFO(h crypto.Hash, sizeBits uint32, saltLen int, sign bool) (info bcrypt.PSS_PADDING_INFO, err error) {
 	hashID := cryptoHashToID(h)
 	if hashID == "" {
 		return info, errors.New("crypto/rsa: unsupported hash function")
@@ -326,11 +328,6 @@ func newPSS_PADDING_INFO(pkey bcrypt.KEY_HANDLE, h crypto.Hash, saltLen int, sig
 		info.Salt = uint32(h.Size())
 	case 0: // rsa.PSSSaltLengthAuto
 		if sign {
-			// Go sets the salt as large as possible when signing.
-			sizeBits, err := getUint32(bcrypt.HANDLE(pkey), bcrypt.KEY_LENGTH)
-			if err != nil {
-				return info, errors.New("crypto/rsa: key length can't be retrieved " + err.Error())
-			}
 			// Algorithm taken from RFC 3447 Section 9.1.1, which is also implemented by Go at
 			// https://github.com/golang/go/blob/54182ff54a687272dd7632c3a963e036ce03cb7c/src/crypto/rsa/pss.go#L288.
 			emLen := (sizeBits - 1 + 7) / 8

--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -250,9 +250,9 @@ func BenchmarkGenerateKeyRSA(b *testing.B) {
 
 func TestSignWithPSSSaltLengthAuto(t *testing.T) {
 	privGo, _ := rsa.GenerateKey(cng.RandReader, 513)
-	priv, err := cng.NewPrivateKeyRSA(bbig.Enc(privGo.N), bbig.Enc(big.NewInt(int64(privGo.E))), bbig.Enc(privGo.D),
-		bbig.Enc(privGo.Primes[0]), bbig.Enc(privGo.Primes[1]),
-		bbig.Enc(privGo.Precomputed.Dp), bbig.Enc(privGo.Precomputed.Dq), bbig.Enc(privGo.Precomputed.Qinv),
+	priv, err := cng.NewPrivateKeyRSA(
+		bbig.Enc(privGo.N), bbig.Enc(big.NewInt(int64(privGo.E))), bbig.Enc(privGo.D),
+		bbig.Enc(privGo.Primes[0]), bbig.Enc(privGo.Primes[1]), nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/rsa"
+	"crypto/sha256"
 	"math/big"
 	"strconv"
 	"testing"
@@ -244,5 +245,24 @@ func BenchmarkGenerateKeyRSA(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestSignWithPSSSaltLengthAuto(t *testing.T) {
+	privGo, _ := rsa.GenerateKey(cng.RandReader, 513)
+	priv, err := cng.NewPrivateKeyRSA(bbig.Enc(privGo.N), bbig.Enc(big.NewInt(int64(privGo.E))), bbig.Enc(privGo.D),
+		bbig.Enc(privGo.Primes[0]), bbig.Enc(privGo.Primes[1]),
+		bbig.Enc(privGo.Precomputed.Dp), bbig.Enc(privGo.Precomputed.Dq), bbig.Enc(privGo.Precomputed.Qinv),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256([]byte("message"))
+	signature, err := cng.SignRSAPSS(priv, crypto.SHA256, digest[:], rsa.PSSSaltLengthAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(signature) == 0 {
+		t.Fatal("empty signature returned")
 	}
 }

--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -265,4 +265,8 @@ func TestSignWithPSSSaltLengthAuto(t *testing.T) {
 	if len(signature) == 0 {
 		t.Fatal("empty signature returned")
 	}
+	err = rsa.VerifyPSS(&privGo.PublicKey, crypto.SHA256, digest[:], signature, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto})
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Some of the latest changes in this repo have broken some upstream Go test running with the CNG backend: https://dev.azure.com/dnceng-public/public/_build/results?buildId=36110&view=ms.vss-test-web.build-test-results-tab&runId=720402&resultId=103562&paneView=debug

This PR contains fixes for the two different failure modes identifies:

- We need the RSA key bit length to calculate the maximum allowed salt length for when the user wants to sign using `rsa.PSSSaltLengthAuto`.  The support for this case was recently implemented in #27, but we didn't test that it worked with RSA keys whose length is not multiple of 8.
Although CNG only allows to generate RSA keys with lengths multiple of 8, one can generate a key of whatever size (e.g., 513) outside CNG (e.g., Go crypto) and import it into CNG using `cng.NewPrivateKeyRSA(...)`. The resulting CNG key can be used to sign payloads, but when we get the bit length property for that key, it reports a number multiple of 8 instead of the true size, so we can't use this property to calculate the maximum size length.
This PR change how we retrieve the key length, getting it from `N` when the key is instantiated instead of from the `BCRYPT_KEY_LENGTH` property when we are signing.
- #28 introduced a check that verifies `cng.NewPrivateKeyRSA` private key parameters (all except `N` and `E`) are not nil if `D` is present. This check happens to be too restrictive, as Go and CNG allow the precomputed parameters (`Dp`, `Dq`, and `Qinv`) to be nil.