### PR TITLE
Fix int overflow on 32-bit windows

### DIFF
--- a/cng/cng.go
+++ b/cng/cng.go
@@ -25,11 +25,11 @@ func FIPS() (bool, error) {
 	return enabled, nil
 }
 
-// lenU32 clamps s length so it can fit into a Win32 ULONG,
-// which is a 32-bit unsigned integer, without overflowing.
-func lenU32(s []byte) int {
-	if len(s) > math.MaxUint32 {
-		return math.MaxUint32
+// len32 clamps s length so it can fit into a Win32 LONG,
+// which is a 32-bit signed integer, without overflowing.
+func len32(s []byte) int {
+	if len(s) > math.MaxInt32 {
+		return math.MaxInt32
 	}
 	return len(s)
 }

--- a/cng/rand.go
+++ b/cng/rand.go
@@ -16,7 +16,7 @@ func (randReader) Read(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	n := lenU32(b)
+	n := len32(b)
 	const flags = bcrypt.USE_SYSTEM_PREFERRED_RNG
 	err := bcrypt.GenRandom(0, b[:n], flags)
 	if err != nil {

--- a/cng/sha.go
+++ b/cng/sha.go
@@ -159,7 +159,7 @@ func (h *shaXHash) Reset() {
 
 func (h *shaXHash) Write(p []byte) (n int, err error) {
 	for n < len(p) && err == nil {
-		nn := lenU32(p[n:])
+		nn := len32(p[n:])
 		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
 		n += nn
 	}


### PR DESCRIPTION
This PR fixes `lenU32` so it does not overflow when using `windows/386`.