### PR TITLE
Update GenerateKeyECDH to return private bytes instead of public ones

### DIFF
--- a/cng/ecdh.go
+++ b/cng/ecdh.go
@@ -126,11 +126,15 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	// GenerateKeyECDH returns the public key as as byte slice.
 	// To get it we need to export the raw CNG key blob
 	// and prepend the encoding prefix.
-	_, bytes, err := exportECCKey(hkey, true)
+	hdr, bytes, err := exportECCKey(hkey, true)
 	if err != nil {
 		bcrypt.DestroyKey(hkey)
 		return nil, nil, err
 	}
+	// Only take the private component of the key,
+	// which is the last of the three equally-sized chunks.
+	bytes = bytes[hdr.KeySize*2:]
+
 	k := &PrivateKeyECDH{hkey, isNIST(curve)}
 	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
 	return k, bytes, nil

--- a/cng/ecdh.go
+++ b/cng/ecdh.go
@@ -126,22 +126,13 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	// GenerateKeyECDH returns the public key as as byte slice.
 	// To get it we need to export the raw CNG key blob
 	// and prepend the encoding prefix.
-	hdr, blob, err := exportECCKey(hkey, false)
+	_, bytes, err := exportECCKey(hkey, true)
 	if err != nil {
 		bcrypt.DestroyKey(hkey)
 		return nil, nil, err
 	}
 	k := &PrivateKeyECDH{hkey, isNIST(curve)}
 	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
-	var bytes []byte
-	if k.isNIST {
-		bytes = append([]byte{ecdhUncompressedPrefix}, blob...)
-	} else {
-		// X25519 bytes must only contain the X coordinate,
-		// but BCrypt might export X and Y.
-		// Slice blob so it only contains X.
-		bytes = blob[:hdr.KeySize]
-	}
 	return k, bytes, nil
 }
 

--- a/cng/ecdh.go
+++ b/cng/ecdh.go
@@ -123,9 +123,8 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 		return nil, nil, err
 	}
 
-	// GenerateKeyECDH returns the public key as as byte slice.
-	// To get it we need to export the raw CNG key blob
-	// and prepend the encoding prefix.
+	// GenerateKeyECDH returns the private key as a byte slice.
+	// To get it we need to export the raw CNG key bytes.
 	hdr, bytes, err := exportECCKey(hkey, true)
 	if err != nil {
 		bcrypt.DestroyKey(hkey)

--- a/cng/ecdh_test.go
+++ b/cng/ecdh_test.go
@@ -21,28 +21,29 @@ func TestECDH(t *testing.T) {
 	for _, tt := range []string{"P-256", "P-384", "P-521", "X25519"} {
 		t.Run(tt, func(t *testing.T) {
 			name := tt
-			aliceKey, aliceBytes, err := cng.GenerateKeyECDH(name)
+			aliceKey, _, err := cng.GenerateKeyECDH(name)
 			if err != nil {
 				t.Fatal(err)
 			}
-			bobKey, bobBytes, err := cng.GenerateKeyECDH(name)
+			bobKey, _, err := cng.GenerateKeyECDH(name)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			alicePubKey, err := cng.NewPublicKeyECDH(name, aliceBytes)
-			if err != nil {
-				t.Error(err)
-			}
 			alicePubKeyFromPriv, err := aliceKey.PublicKey()
 			if err != nil {
 				t.Error(err)
 			}
-			if !bytes.Equal(alicePubKeyFromPriv.Bytes(), alicePubKey.Bytes()) {
-				t.Error("encoded and decoded public keys are different")
+			alicePubKey, err := cng.NewPublicKeyECDH(name, alicePubKeyFromPriv.Bytes())
+			if err != nil {
+				t.Error(err)
 			}
 
-			bobPubKey, err := cng.NewPublicKeyECDH(name, bobBytes)
+			blobPubKeyFromPriv, err := bobKey.PublicKey()
+			if err != nil {
+				t.Error(err)
+			}
+			bobPubKey, err := cng.NewPublicKeyECDH(name, blobPubKeyFromPriv.Bytes())
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
I misinterpreted the second return parameter of [boring.GenerateKeyECDH](https://github.com/golang/go/blob/ea4631cc0cf301c824bd665a7980c13289ab5c9d/src/crypto/internal/boring/ecdh.go#L190). It is meant to contain the private bytes of the key, but we are returning the public bytes. We haven't found this mismatch until now because boring support for ECDH landed just 4 days ago in [CL 423363](https://go-review.googlesource.com/c/go/+/423363).

This PR updates `GenerateKeyECDH` so it matches upstream behavior.
