### PR TITLE
Set PublicKeyECDH key handle when creating a public key from a private one

### DIFF
--- a/cng/ecdh.go
+++ b/cng/ecdh.go
@@ -209,14 +209,15 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 	if err != nil {
 		return nil, err
 	}
-	pub := new(PublicKeyECDH)
+	var bytes []byte
 	if k.isNIST {
 		// Include X and Y.
-		pub.bytes = append([]byte{ecdhUncompressedPrefix}, data...)
+		bytes = append([]byte{ecdhUncompressedPrefix}, data...)
 	} else {
 		// Only include X.
-		pub.bytes = data[:hdr.KeySize]
+		bytes = data[:hdr.KeySize]
 	}
+	pub := &PublicKeyECDH{k.hkey, bytes}
 	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 	return pub, nil
 }

--- a/cng/ecdh_test.go
+++ b/cng/ecdh_test.go
@@ -54,7 +54,7 @@ func TestECDH(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			bobPubKey, err := cng.NewPublicKeyECDH(name, bobPubKeyFromPriv.Bytes())
+			_, err = cng.NewPublicKeyECDH(name, bobPubKeyFromPriv.Bytes())
 			if err != nil {
 				t.Error(err)
 			}
@@ -63,7 +63,7 @@ func TestECDH(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			aliceSecret, err := cng.ECDH(aliceKey, bobPubKey)
+			aliceSecret, err := cng.ECDH(aliceKey, bobPubKeyFromPriv)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR fixes a bug in `PrivateKeyECDH.PublicKey()`, where the returned public key is not correctly initialized and fails when used in `ECDH()`.