### PR TITLE
Fix use-after-free and double-free bugs on ECDH keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
     - name: Set FIPS mode
       run: REG ADD HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /f /d ${{ matrix.fips }}
     - name: Run Test - Short
-      run: go test -v -gcflags=all=-d=checkptr -count 1 -short ./...
+      run: go test -v -gcflags=all=-d=checkptr -count 1 ./...
       env:
         GO_TEST_FIPS: ${{ matrix.fips }}
     - name: Run Test - Long
       # Run each test 10 times so the garbage collector chimes in 
       # and exercises the multiple finalizers we use.
       # This can detect use-after-free and double-free issues.
-      run: go test -v -gcflags=all=-d=checkptr -count 10 ./...
+      run: go test -v -gcflags=all=-d=checkptr -count 10 -short ./...
       env:
         GO_TEST_FIPS: ${{ matrix.fips }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,14 @@ jobs:
       uses: actions/checkout@v2
     - name: Set FIPS mode
       run: REG ADD HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /f /d ${{ matrix.fips }}
-    - name: Run Test - Build
-      run: go test -v -gcflags=all=-d=checkptr ./...
+    - name: Run Test - Short
+      run: go test -v -gcflags=all=-d=checkptr -count 1 -short ./...
+      env:
+        GO_TEST_FIPS: ${{ matrix.fips }}
+    - name: Run Test - Long
+      # Run each test 10 times so the garbage collector chimes in 
+      # and exercises the multiple finalizers we use.
+      # This can detect use-after-free and double-free issues.
+      run: go test -v -gcflags=all=-d=checkptr -count 10 ./...
       env:
         GO_TEST_FIPS: ${{ matrix.fips }}

--- a/cng/rand_test.go
+++ b/cng/rand_test.go
@@ -23,6 +23,10 @@ func TestRand(t *testing.T) {
 }
 
 func TestRandBig(t *testing.T) {
+	if testing.Short() {
+		// This test can take ~20s to complete.
+		t.Skip("skipping test in short mode.")
+	}
 	b := make([]byte, 1<<32+60)
 	n, err := io.ReadFull(RandReader, b)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a couple of memory issues produced when calling `PrivateKeyECDH.PublicKey()`.

The underlying problem is that this method creates a public key that shares the same `bcrypt.KEY_HANDLE` instance with the private key. This KEY_HANDLE is freed when any of the keys is garbage collected, leaving the other key with an invalid KEY_HANDLE that will probably crash the application when it is used.

I've also improved the test pipeline so it has more chances to detect this memory bugs.

Thanks @dagood for finding and investigating this issue.