### PR TITLE
sha: add WriteString and WriteByte method

### DIFF
--- a/cng/sha.go
+++ b/cng/sha.go
@@ -183,8 +183,12 @@ func (h *shaXHash) WriteString(s string) (int, error) {
 }
 
 func (h *shaXHash) WriteByte(c byte) error {
-	defer runtime.KeepAlive(h)
-	return bcrypt.HashDataRaw(h.ctx, &c, 1, 0)
+	if err := bcrypt.HashDataRaw(h.ctx, &c, 1, 0); err != nil {
+		// hash.Hash interface mandates Write should never return an error.
+		panic(err)
+	}
+	runtime.KeepAlive(h)
+	return nil
 }
 
 func (h *shaXHash) Size() int {

--- a/cng/sha.go
+++ b/cng/sha.go
@@ -183,6 +183,7 @@ func (h *shaXHash) WriteString(s string) (int, error) {
 }
 
 func (h *shaXHash) WriteByte(c byte) error {
+	defer runtime.KeepAlive(h)
 	return bcrypt.HashDataRaw(h.ctx, &c, 1, 0)
 }
 

--- a/cng/sha.go
+++ b/cng/sha.go
@@ -9,6 +9,7 @@ package cng
 import (
 	"hash"
 	"runtime"
+	"unsafe"
 
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
 )
@@ -169,6 +170,20 @@ func (h *shaXHash) Write(p []byte) (n int, err error) {
 	}
 	runtime.KeepAlive(h)
 	return len(p), nil
+}
+
+func (h *shaXHash) WriteString(s string) (int, error) {
+	// TODO: use unsafe.StringData once we drop support
+	// for go1.19 and earlier.
+	hdr := (*struct {
+		Data *byte
+		Len  int
+	})(unsafe.Pointer(&s))
+	return h.Write(unsafe.Slice(hdr.Data, len(s)))
+}
+
+func (h *shaXHash) WriteByte(c byte) error {
+	return bcrypt.HashDataRaw(h.ctx, &c, 1, 0)
 }
 
 func (h *shaXHash) Size() int {

--- a/cng/sha_test.go
+++ b/cng/sha_test.go
@@ -9,6 +9,7 @@ package cng_test
 import (
 	"bytes"
 	"hash"
+	"io"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
@@ -54,6 +55,23 @@ func TestSha(t *testing.T) {
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
 				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", tt.name, msg, actual, actual2)
 			}
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			bw := h.(io.ByteWriter)
+			for i := 0; i < len(msg); i++ {
+				bw.WriteByte(msg[i])
+			}
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			h.(io.StringWriter).WriteString(string(msg))
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -197,6 +197,7 @@ func Encrypt(hKey KEY_HANDLE, plaintext []byte, pPaddingInfo unsafe.Pointer, pbI
 //sys	CreateHash(hAlgorithm ALG_HANDLE, phHash *HASH_HANDLE, pbHashObject []byte, pbSecret []byte, dwFlags uint32) (s error) = bcrypt.BCryptCreateHash
 //sys	DestroyHash(hHash HASH_HANDLE) (s error) = bcrypt.BCryptDestroyHash
 //sys   HashData(hHash HASH_HANDLE, pbInput []byte, dwFlags uint32) (s error) = bcrypt.BCryptHashData
+//sys   HashDataRaw(hHash HASH_HANDLE, pbInput *byte, cbInput uint32, dwFlags uint32) (s error) = bcrypt.BCryptHashData
 //sys   DuplicateHash(hHash HASH_HANDLE,  phNewHash *HASH_HANDLE, pbHashObject []byte, dwFlags uint32) (s error) = bcrypt.BCryptDuplicateHash
 //sys   FinishHash(hHash HASH_HANDLE, pbOutput []byte, dwFlags uint32) (s error) = bcrypt.BCryptFinishHash
 

--- a/internal/bcrypt/zsyscall_windows.go
+++ b/internal/bcrypt/zsyscall_windows.go
@@ -287,6 +287,14 @@ func Hash(hAlgorithm ALG_HANDLE, pbSecret []byte, pbInput []byte, pbOutput []byt
 	return
 }
 
+func HashDataRaw(hHash HASH_HANDLE, pbInput *byte, cbInput uint32, dwFlags uint32) (s error) {
+	r0, _, _ := syscall.Syscall6(procBCryptHashData.Addr(), 4, uintptr(hHash), uintptr(unsafe.Pointer(pbInput)), uintptr(cbInput), uintptr(dwFlags), 0, 0)
+	if r0 != 0 {
+		s = syscall.Errno(r0)
+	}
+	return
+}
+
 func HashData(hHash HASH_HANDLE, pbInput []byte, dwFlags uint32) (s error) {
 	var _p0 *byte
 	if len(pbInput) > 0 {


### PR DESCRIPTION
This PR implements `WriteString` and `WriteByte` for all supported hashers. These methods will be required by the boring API in go1.21.

See [CL 483816](https://go-review.googlesource.com/c/go/+/483816), [483815](https://go-review.googlesource.com/c/go/+/483815), and [CL 481478](https://go-review.googlesource.com/c/go/+/481478).