### PR TITLE
Avoid panic with empty salt in PBKDF2

### DIFF
--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -40,22 +40,24 @@ func PBKDF2(password, salt []byte, iter, keyLen int, h func() hash.Hash) ([]byte
 	}
 	defer bcrypt.DestroyKey(kh)
 	u16HashID := utf16FromString(hashID)
-	buffers := [...]bcrypt.Buffer{
-		{
-			Type:   bcrypt.KDF_ITERATION_COUNT,
-			Data:   uintptr(unsafe.Pointer(&iter)),
-			Length: 8,
-		},
-		{
+	buffers := make([]bcrypt.Buffer, 2, 3)
+	buffers[0] = bcrypt.Buffer{
+		Type:   bcrypt.KDF_ITERATION_COUNT,
+		Data:   uintptr(unsafe.Pointer(&iter)),
+		Length: 8,
+	}
+	buffers[1] = bcrypt.Buffer{
+		Type:   bcrypt.KDF_HASH_ALGORITHM,
+		Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
+		Length: uint32(len(u16HashID) * 2),
+	}
+	if len(salt) > 0 {
+		// The salt is optional.
+		buffers = append(buffers, bcrypt.Buffer{
 			Type:   bcrypt.KDF_SALT,
 			Data:   uintptr(unsafe.Pointer(&salt[0])),
 			Length: uint32(len(salt)),
-		},
-		{
-			Type:   bcrypt.KDF_HASH_ALGORITHM,
-			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
-			Length: uint32(len(u16HashID) * 2),
-		},
+		})
 	}
 	params := &bcrypt.BufferDesc{
 		Count:   uint32(len(buffers)),

--- a/cng/pbkdf2_test.go
+++ b/cng/pbkdf2_test.go
@@ -164,6 +164,21 @@ func TestWithHMACSHA256(t *testing.T) {
 	testHash(t, cng.NewSHA256, "SHA256", sha256TestVectors)
 }
 
+func TestPBKDF2NoSalt(t *testing.T) {
+	vectors := []testVector{
+		{
+			"pass\000word",
+			"",
+			4096,
+			[]byte{
+				0x65, 0x6b, 0xbf, 0xf8, 0xdb, 0x07, 0x95, 0x8b,
+				0x1c, 0xfe, 0x17, 0x80, 0x16, 0xa0, 0x4d, 0x62,
+			},
+		},
+	}
+	testHash(t, cng.NewSHA256, "SHA256", vectors)
+}
+
 var sink uint8
 
 func benchmark(b *testing.B, h func() hash.Hash) {


### PR DESCRIPTION
Upstream x/crypto/pbkdf2 allows passing an empty salt, so should we.