### PR TITLE
tls1prf: require callers to pass in the result buffer

### DIFF
--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -24,7 +24,7 @@ func loadTLS1PRF(id string) (bcrypt.ALG_HANDLE, error) {
 	return h.(bcrypt.ALG_HANDLE), nil
 }
 
-// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil or crypto.MD5SHA1,
+// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil,
 // else it implements the TLS 1.2 pseudo-random function.
 // The pseudo-random number will be written to result and will be of length len(result).
 func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
@@ -81,8 +81,10 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 	if err != nil {
 		return err
 	}
+	// The Go standard library expects TLS1PRF to return the requested number of bytes,
+	// fail if it doesn't.
 	if size != uint32(len(result)) {
-		return errors.New("tls1-prf: entropy limit reached")
+		return errors.New("tls1-prf: derived less bytes than requested")
 	}
 	return nil
 }

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -24,7 +24,10 @@ func loadTLS1PRF(id string) (bcrypt.ALG_HANDLE, error) {
 	return h.(bcrypt.ALG_HANDLE), nil
 }
 
-func TLS1PRF(secret, label, seed []byte, keyLen int, h func() hash.Hash) ([]byte, error) {
+// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil or crypto.MD5SHA1,
+// else it implements the TLS 1.2 pseudo-random function.
+// The pseudo-random number will be written to result and will be of length len(result).
+func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 	// TLS 1.0/1.1 PRF uses MD5SHA1.
 	algID := bcrypt.TLS1_1_KDF_ALGORITHM
 	var hashID string
@@ -32,18 +35,18 @@ func TLS1PRF(secret, label, seed []byte, keyLen int, h func() hash.Hash) ([]byte
 		// If h is specified, assume the caller wants to use TLS 1.2 PRF.
 		// TLS 1.0/1.1 PRF doesn't allow specifying the hash function.
 		if hashID = hashToID(h()); hashID == "" {
-			return nil, errors.New("cng: unsupported hash function")
+			return errors.New("cng: unsupported hash function")
 		}
 		algID = bcrypt.TLS1_2_KDF_ALGORITHM
 	}
 
 	alg, err := loadTLS1PRF(algID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	var kh bcrypt.KEY_HANDLE
 	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, secret, 0); err != nil {
-		return nil, err
+		return err
 	}
 
 	buffers := make([]bcrypt.Buffer, 0, 3)
@@ -73,11 +76,13 @@ func TLS1PRF(secret, label, seed []byte, keyLen int, h func() hash.Hash) ([]byte
 		Count:   uint32(len(buffers)),
 		Buffers: &buffers[0],
 	}
-	out := make([]byte, keyLen)
 	var size uint32
-	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
+	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return out[:size], nil
+	if size != uint32(len(result)) {
+		return errors.New("tls1-prf: entropy limit reached")
+	}
+	return nil
 }

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -82,7 +82,9 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 		return err
 	}
 	// The Go standard library expects TLS1PRF to return the requested number of bytes,
-	// fail if it doesn't.
+	// fail if it doesn't. While there is no known situation where this will happen,
+	// BCryptKeyDerivation handles multiple algorithms and there could be a subtle mismatch
+	// after more code changes in the future.
 	if size != uint32(len(result)) {
 		return errors.New("tls1-prf: derived less bytes than requested")
 	}

--- a/cng/tls1prf_test.go
+++ b/cng/tls1prf_test.go
@@ -153,12 +153,13 @@ var tls1prfTests = []tls1prfTest{
 
 func TestTLS1PRF(t *testing.T) {
 	for i, tt := range tls1prfTests {
-		out, err := cng.TLS1PRF(tt.secret, tt.label, tt.seed, len(tt.out), tt.hash)
+		result := make([]byte, len(tt.out))
+		err := cng.TLS1PRF(result, tt.secret, tt.label, tt.seed, tt.hash)
 		if err != nil {
 			t.Errorf("test %d: error deriving TLS 1.2 PRF: %v.", i, err)
 		}
-		if !bytes.Equal(out, tt.out) {
-			t.Errorf("test %d: incorrect key output: have %v, need %v.", i, out, tt.out)
+		if !bytes.Equal(result, tt.out) {
+			t.Errorf("test %d: incorrect key output: have %v, need %v.", i, result, tt.out)
 		}
 	}
 }


### PR DESCRIPTION
This PR updates `TLS1PRF` to accept a byte slice parameter where to write the output. This avoids allocating a new slice on each function call and integrates better with the standard library, which expects the PRF to update an already existing slice: https://github.com/golang/go/blob/2f0b28da1900909a2c3ddf646bb508fc7effb8f2/src/crypto/tls/prf.go#L68.

To make is clear, the current code would have to be integrated like this:

```go
func prf12(hashFunc func() hash.Hash) func(result, secret, label, seed []byte) error {
	return func(result, secret, label, seed []byte) error {
		if backend.Enabled && backend.SupportsTLS1PRF() {
			out, err := backend.TLS1PRF(secret, label, seed, len(result), hashFunc)
			if err != nil {
				return fmt.Errorf("crypto/tls: prf12: %v", err)
			}
			copy(result, out)
			return nil
		}
                ...
	}
}
```

While with the new approach, it would like this:

```go
func prf12(hashFunc func() hash.Hash) func(result, secret, label, seed []byte) error {
	return func(result, secret, label, seed []byte) error {
		if backend.Enabled && backend.SupportsTLS1PRF() {
			err := backend.TLS1PRF(result, secret, label, seed, len(result), hashFunc)
			if err != nil {
				return fmt.Errorf("crypto/tls: prf12: %v", err)
			}
			return nil
		}
                ...
	}
}
```