### PR TITLE
Fix 3DES-CBC

### DIFF
--- a/cng/aes.go
+++ b/cng/aes.go
@@ -133,7 +133,7 @@ func newCBC(encrypt bool, alg string, key, iv []byte) *cbcCipher {
 	switch alg {
 	case bcrypt.AES_ALGORITHM:
 		blockSize = aesBlockSize
-	case bcrypt.DES_ALGORITHM:
+	case bcrypt.DES_ALGORITHM, bcrypt.DES3_ALGORITHM:
 		blockSize = desBlockSize
 	default:
 		panic("invalid algorithm: " + alg)

--- a/cng/des.go
+++ b/cng/des.go
@@ -18,6 +18,7 @@ const desBlockSize = 8
 
 type desCipher struct {
 	kh  bcrypt.KEY_HANDLE
+	alg string
 	key []byte
 }
 
@@ -26,7 +27,7 @@ func NewDESCipher(key []byte) (cipher.Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &desCipher{kh: kh, key: make([]byte, len(key))}
+	c := &desCipher{kh: kh, alg: bcrypt.DES_ALGORITHM, key: make([]byte, len(key))}
 	copy(c.key, key)
 	runtime.SetFinalizer(c, (*desCipher).finalize)
 	return c, nil
@@ -37,7 +38,7 @@ func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &desCipher{kh: kh, key: make([]byte, len(key))}
+	c := &desCipher{kh: kh, alg: bcrypt.DES3_ALGORITHM, key: make([]byte, len(key))}
 	copy(c.key, key)
 	runtime.SetFinalizer(c, (*desCipher).finalize)
 	return c, nil
@@ -98,9 +99,9 @@ func (c *desCipher) Decrypt(dst, src []byte) {
 }
 
 func (c *desCipher) NewCBCEncrypter(iv []byte) cipher.BlockMode {
-	return newCBC(true, bcrypt.DES_ALGORITHM, c.key, iv)
+	return newCBC(true, c.alg, c.key, iv)
 }
 
 func (c *desCipher) NewCBCDecrypter(iv []byte) cipher.BlockMode {
-	return newCBC(false, bcrypt.DES_ALGORITHM, c.key, iv)
+	return newCBC(false, c.alg, c.key, iv)
 }


### PR DESCRIPTION
`NewCBCEncrypter` and `NewCBCDecrypter` implementations for 3DES are broken, we are passing the incorrect algorithm identifier when constructing the BCrypt algorithm handle.

This PR fixes it and adds some tests to ensure there are no regressions.