### PR TITLE
Optimize multiple hkdf reads case

### DIFF
--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -38,44 +38,73 @@ type hkdf struct {
 
 	hashLen int
 	buf     []byte
+	n       int
 }
 
 func (c *hkdf) finalize() {
 	bcrypt.DestroyKey(c.hkey)
 }
 
-func (c *hkdf) Read(p []byte) (int, error) {
+func hkdfDerive(hkey bcrypt.KEY_HANDLE, info, out []byte) (int, error) {
 	var params *bcrypt.BufferDesc
-	if len(c.info) > 0 {
+	if len(info) > 0 {
 		params = &bcrypt.BufferDesc{
 			Count: 1,
 			Buffers: &bcrypt.Buffer{
-				Length: uint32(len(c.info)),
+				Length: uint32(len(info)),
 				Type:   bcrypt.KDF_HKDF_INFO,
-				Data:   uintptr(unsafe.Pointer(&c.info[0])),
+				Data:   uintptr(unsafe.Pointer(&info[0])),
 			},
 		}
+		defer runtime.KeepAlive(params)
 	}
+	var n uint32
+	err := bcrypt.KeyDerivation(hkey, params, out, &n, 0)
+	return int(n), err
+}
+
+func (c *hkdf) Read(p []byte) (int, error) {
 	// KeyDerivation doesn't support incremental output, each call
 	// derives the key from scratch and returns the requested bytes.
 	// To implement io.Reader, we need to ask for len(c.buf) + len(p)
 	// bytes and copy the last derived len(p) bytes to p.
-	// We use c.buf to know how many bytes we've already derived and
-	// to avoid allocating the whole output buffer on each call.
-	prevLen := len(c.buf)
-	needLen := len(p)
-	remains := 255*c.hashLen - prevLen
-	// Check whether enough data can be generated.
-	if remains < needLen {
+	maxDerived := 255 * c.hashLen
+	totalDerived := c.n + len(p)
+	// Check whether enough data can be derived.
+	if totalDerived > maxDerived {
 		return 0, errors.New("hkdf: entropy limit reached")
 	}
-	c.buf = append(c.buf, make([]byte, needLen)...)
-	var size uint32
-	if err := bcrypt.KeyDerivation(c.hkey, params, c.buf, &size, 0); err != nil {
-		return 0, err
+	// Check whether c.buf already contains enough derived data,
+	// otherwise derive more data.
+	if bytesNeeded := totalDerived - len(c.buf); bytesNeeded > 0 {
+		// It is common to derive multiple equally sized keys from the same HKDF instance.
+		// Optimize this case by allocating a buffer large enough to hold
+		// at least 5 of such keys each time there is not enough data.
+		blocks := bytesNeeded / c.hashLen
+		if bytesNeeded%c.hashLen != 0 {
+			// Round up to the next multiple of hashLen.
+			blocks += 1
+		}
+		const minBlocks = 5
+		if blocks < minBlocks {
+			blocks = minBlocks
+		}
+		alloc := blocks * c.hashLen
+		if len(c.buf)+alloc > maxDerived {
+			// The buffer can't grow beyond maxDerived.
+			alloc = maxDerived - len(c.buf)
+		}
+		c.buf = append(c.buf, make([]byte, alloc)...)
+		n, err := hkdfDerive(c.hkey, c.info, c.buf)
+		if err != nil {
+			c.buf = c.buf[:c.n]
+			return 0, err
+		}
+		// Adjust totalDerived to the actual number of bytes derived.
+		totalDerived = c.n + n
 	}
-	runtime.KeepAlive(params)
-	n := copy(p, c.buf[prevLen:size])
+	n := copy(p, c.buf[c.n:totalDerived])
+	c.n += n
 	return n, nil
 }
 
@@ -108,7 +137,7 @@ func newHKDF(h func() hash.Hash, secret, salt []byte, info []byte) (*hkdf, error
 		bcrypt.DestroyKey(kh)
 		return nil, err
 	}
-	k := &hkdf{kh, info, ch.Size(), nil}
+	k := &hkdf{kh, info, ch.Size(), nil, 0}
 	runtime.SetFinalizer(k, (*hkdf).finalize)
 	return k, nil
 }

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -140,7 +140,7 @@ func newHKDF(h func() hash.Hash, secret, salt []byte, info []byte) (*hkdf, error
 		bcrypt.DestroyKey(kh)
 		return nil, err
 	}
-	k := &hkdf{kh, info, ch.Size(), nil, 0}
+	k := &hkdf{kh, info, ch.Size(), 0, nil}
 	runtime.SetFinalizer(k, (*hkdf).finalize)
 	return k, nil
 }

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -83,11 +83,8 @@ func (c *hkdf) Read(p []byte) (int, error) {
 		// It is common to derive multiple equally sized keys from the same HKDF instance.
 		// Optimize this case by allocating a buffer large enough to hold
 		// at least 3 of such keys each time there is not enough data.
-		blocks := bytesNeeded / c.hashLen
-		if bytesNeeded%c.hashLen != 0 {
-			// Round up to the next multiple of hashLen.
-			blocks += 1
-		}
+		// Round up to the next multiple of hashLen.
+		blocks := (bytesNeeded-1)/c.hashLen + 1
 		const minBlocks = 3
 		if blocks < minBlocks {
 			blocks = minBlocks

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -79,13 +79,13 @@ func (c *hkdf) Read(p []byte) (int, error) {
 	if bytesNeeded := totalDerived - len(c.buf); bytesNeeded > 0 {
 		// It is common to derive multiple equally sized keys from the same HKDF instance.
 		// Optimize this case by allocating a buffer large enough to hold
-		// at least 5 of such keys each time there is not enough data.
+		// at least 3 of such keys each time there is not enough data.
 		blocks := bytesNeeded / c.hashLen
 		if bytesNeeded%c.hashLen != 0 {
 			// Round up to the next multiple of hashLen.
 			blocks += 1
 		}
-		const minBlocks = 5
+		const minBlocks = 3
 		if blocks < minBlocks {
 			blocks = minBlocks
 		}
@@ -101,7 +101,7 @@ func (c *hkdf) Read(p []byte) (int, error) {
 			return 0, err
 		}
 		// Adjust totalDerived to the actual number of bytes derived.
-		totalDerived = c.n + n
+		totalDerived = n
 	}
 	n := copy(p, c.buf[c.n:totalDerived])
 	c.n += n

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -37,8 +37,11 @@ type hkdf struct {
 	info []byte
 
 	hashLen int
-	buf     []byte
-	n       int
+	n       int // count of bytes requested from Read
+	// buf contains the derived data.
+	// len(buf) can be larger than n, as Read may derive
+	// more data than requested and cache it in buf.
+	buf []byte
 }
 
 func (c *hkdf) finalize() {

--- a/cng/hkdf_test.go
+++ b/cng/hkdf_test.go
@@ -394,15 +394,15 @@ func TestHKDFLimit(t *testing.T) {
 	}
 }
 
-func Benchmark32ByteSHA256Single(b *testing.B) {
+func BenchmarkHKDF32ByteSHA256Single(b *testing.B) {
 	benchmarkHKDFSingle(cng.NewSHA256, 32, b)
 }
 
-func Benchmark8ByteSHA256Stream(b *testing.B) {
+func BenchmarkHKDF8ByteSHA256Stream(b *testing.B) {
 	benchmarkHKDFStream(cng.NewSHA256, 8, b)
 }
 
-func Benchmark32ByteSHA256Stream(b *testing.B) {
+func BenchmarkHKDF32ByteSHA256Stream(b *testing.B) {
 	benchmarkHKDFStream(cng.NewSHA256, 32, b)
 }
 


### PR DESCRIPTION
This PR optimize the case of deriving multiple keys from the same hkdf instance by batching `BCryptKeyDerivation` calls.

The following benchmarks demonstrates that the throughput of multiple read cases (suffixed with `Stream`) have been boosted by 200%-1000% without hurting the single read call case.

```
goos: windows
goarch: amd64
pkg: github.com/microsoft/go-crypto-winnative/cng
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
                          │   old.txt    │               new.txt               │
                          │    sec/op    │   sec/op     vs base                │
HKDF32ByteSHA256Single-12    8.316µ ± 4%   8.481µ ± 3%        ~ (p=0.305 n=10)
HKDF8ByteSHA256Stream-12    70.311µ ± 2%   6.035µ ± 1%  -91.42% (p=0.000 n=10)
HKDF32ByteSHA256Stream-12    74.22µ ± 8%   24.29µ ± 1%  -67.27% (p=0.000 n=10)
geomean                      35.14µ        10.75µ       -69.40%

                          │   old.txt    │                 new.txt                 │
                          │     B/s      │      B/s       vs base                  │
HKDF32ByteSHA256Single-12   3.667Mi ± 4%    3.595Mi ± 3%          ~ (p=0.288 n=10)
HKDF8ByteSHA256Stream-12    107.4Ki ± 0%   1293.9Ki ± 1%  +1104.55% (p=0.000 n=10)
HKDF32ByteSHA256Stream-12   419.9Ki ± 7%   1289.1Ki ± 2%   +206.98% (p=0.000 n=10)
geomean                     553.3Ki         1.788Mi        +230.97%

                          │  old.txt   │              new.txt               │
                          │    B/op    │    B/op     vs base                │
HKDF32ByteSHA256Single-12   448.0 ± 0%   544.0 ± 0%  +21.43% (p=0.000 n=10)
HKDF8ByteSHA256Stream-12    34.00 ± 3%   32.00 ± 0%   -5.88% (p=0.000 n=10)
HKDF32ByteSHA256Stream-12   135.5 ± 0%   130.0 ± 0%   -4.06% (p=0.000 n=10)
geomean                     127.3        131.3        +3.12%

                          │   old.txt    │               new.txt               │
                          │  allocs/op   │ allocs/op   vs base                 │
HKDF32ByteSHA256Single-12   8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
HKDF8ByteSHA256Stream-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HKDF32ByteSHA256Stream-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
```