### PR TITLE
Require at least Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.22.x, 1.23.x]
         venv: [windows-2019, windows-2022]
         fips: [1, 0]
     runs-on: ${{ matrix.venv }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/microsoft/go-crypto-winnative
 
-go 1.17
+go 1.22


### PR DESCRIPTION
We are currently requiring at least Go 1.17, which it is well overdue. This PR bumps the minimum required Go version to 1.22 so we can use newer language features and standard library APIs.