### PR TITLE
Fix missed error return in loadCipher

### DIFF
--- a/cng/cipher.go
+++ b/cng/cipher.go
@@ -34,7 +34,7 @@ func loadCipher(id, mode string) (cipherAlgorithm, error) {
 		return cipherAlgorithm{h, lengths}, nil
 	})
 	if err != nil {
-		return cipherAlgorithm{}, nil
+		return cipherAlgorithm{}, err
 	}
 	return v.(cipherAlgorithm), nil
 }


### PR DESCRIPTION
We were missing to return an error when a cipher algorithm could not be fetched. That error can only occur if there is something wrong in CNG itself or we call `loadCipher` with the wrong arguments, which we are not.

I haven't found a way to trigger this bug from the public API, so I'm not adding a test for it in this PR. I´ll submit a follow-up PR that simplifies all calls to `loadOrStoreAlg` so the caller doesn't have to do the error handling on the calling site.