### PR TITLE
Update `loadOrStoreAlg` to accept type parameters

### DIFF
--- a/cng/cipher.go
+++ b/cng/cipher.go
@@ -18,25 +18,21 @@ type cipherAlgorithm struct {
 }
 
 func loadCipher(id, mode string) (cipherAlgorithm, error) {
-	v, err := loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, mode, func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, mode, func(h bcrypt.ALG_HANDLE) (cipherAlgorithm, error) {
 		if mode != "" {
 			// Windows 8 added support to set the CipherMode value on a key,
 			// but Windows 7 requires that it be set on the algorithm before key creation.
 			err := setString(bcrypt.HANDLE(h), bcrypt.CHAINING_MODE, mode)
 			if err != nil {
-				return nil, err
+				return cipherAlgorithm{}, err
 			}
 		}
 		lengths, err := getKeyLengths(bcrypt.HANDLE(h))
 		if err != nil {
-			return nil, err
+			return cipherAlgorithm{}, err
 		}
 		return cipherAlgorithm{h, lengths}, nil
 	})
-	if err != nil {
-		return cipherAlgorithm{}, nil
-	}
-	return v.(cipherAlgorithm), nil
 }
 
 func newCipherHandle(id, mode string, key []byte) (bcrypt.KEY_HANDLE, error) {

--- a/cng/cng.go
+++ b/cng/cng.go
@@ -52,14 +52,12 @@ func loadOrStoreAlg[T any](id string, flags bcrypt.AlgorithmProviderFlags, mode 
 	var h bcrypt.ALG_HANDLE
 	err := bcrypt.OpenAlgorithmProvider(&h, utf16PtrFromString(id), nil, flags)
 	if err != nil {
-		var t T
-		return t, err
+		return *new(T), err
 	}
 	v, err := fn(h)
 	if err != nil {
 		bcrypt.CloseAlgorithmProvider(h, 0)
-		var t T
-		return t, err
+		return *new(T), err
 	}
 	if existing, loaded := algCache.LoadOrStore(entryKey, v); loaded {
 		// We can safely use a provider that has already been cached in another concurrent goroutine.

--- a/cng/dsa.go
+++ b/cng/dsa.go
@@ -39,17 +39,13 @@ type dsaAlgorithm struct {
 }
 
 func loadDSA() (h dsaAlgorithm, err error) {
-	v, err := loadOrStoreAlg(bcrypt.DSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(bcrypt.DSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (dsaAlgorithm, error) {
 		lengths, err := getKeyLengths(bcrypt.HANDLE(h))
 		if err != nil {
-			return nil, err
+			return dsaAlgorithm{}, err
 		}
 		return dsaAlgorithm{h, lengths}, nil
 	})
-	if err != nil {
-		return dsaAlgorithm{}, err
-	}
-	return v.(dsaAlgorithm), nil
 }
 
 // DSAParameters contains the DSA parameters.

--- a/cng/hash.go
+++ b/cng/hash.go
@@ -157,7 +157,7 @@ type hashAlgorithm struct {
 }
 
 func loadHash(id string, flags bcrypt.AlgorithmProviderFlags) (*hashAlgorithm, error) {
-	v, err := loadOrStoreAlg(id, flags, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(id, flags, "", func(h bcrypt.ALG_HANDLE) (*hashAlgorithm, error) {
 		size, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_LENGTH)
 		if err != nil {
 			return nil, err
@@ -168,10 +168,6 @@ func loadHash(id string, flags bcrypt.AlgorithmProviderFlags) (*hashAlgorithm, e
 		}
 		return &hashAlgorithm{h, id, size, blockSize}, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return v.(*hashAlgorithm), nil
 }
 
 // hashToID converts a hash.Hash implementation from this package

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -23,7 +23,7 @@ func SupportsHKDF() bool {
 }
 
 func loadHKDF() (bcrypt.ALG_HANDLE, error) {
-	return loadOrStoreAlg(bcrypt.HKDF_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
+	return loadOrStoreAlg(bcrypt.HKDF_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
 }

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -23,13 +23,9 @@ func SupportsHKDF() bool {
 }
 
 func loadHKDF() (bcrypt.ALG_HANDLE, error) {
-	h, err := loadOrStoreAlg(bcrypt.HKDF_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(bcrypt.HKDF_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
-	if err != nil {
-		return 0, err
-	}
-	return h.(bcrypt.ALG_HANDLE), nil
 }
 
 type hkdf struct {

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -15,13 +15,9 @@ import (
 )
 
 func loadPBKDF2() (bcrypt.ALG_HANDLE, error) {
-	h, err := loadOrStoreAlg(bcrypt.PBKDF2_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(bcrypt.PBKDF2_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
-	if err != nil {
-		return 0, err
-	}
-	return h.(bcrypt.ALG_HANDLE), nil
 }
 
 func PBKDF2(password, salt []byte, iter, keyLen int, h func() hash.Hash) ([]byte, error) {

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -15,7 +15,7 @@ import (
 )
 
 func loadPBKDF2() (bcrypt.ALG_HANDLE, error) {
-	return loadOrStoreAlg(bcrypt.PBKDF2_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
+	return loadOrStoreAlg(bcrypt.PBKDF2_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
 }

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -22,17 +22,13 @@ type rsaAlgorithm struct {
 }
 
 func loadRsa() (rsaAlgorithm, error) {
-	v, err := loadOrStoreAlg(bcrypt.RSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(bcrypt.RSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (rsaAlgorithm, error) {
 		lengths, err := getKeyLengths(bcrypt.HANDLE(h))
 		if err != nil {
-			return nil, err
+			return rsaAlgorithm{}, err
 		}
 		return rsaAlgorithm{h, lengths}, nil
 	})
-	if err != nil {
-		return rsaAlgorithm{}, err
-	}
-	return v.(rsaAlgorithm), nil
 }
 
 func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -15,7 +15,7 @@ import (
 )
 
 func loadTLS1PRF(id string) (bcrypt.ALG_HANDLE, error) {
-	return loadOrStoreAlg(id, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
+	return loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
 }

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -15,13 +15,9 @@ import (
 )
 
 func loadTLS1PRF(id string) (bcrypt.ALG_HANDLE, error) {
-	h, err := loadOrStoreAlg(id, 0, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
+	return loadOrStoreAlg(id, 0, "", func(h bcrypt.ALG_HANDLE) (bcrypt.ALG_HANDLE, error) {
 		return h, nil
 	})
-	if err != nil {
-		return 0, err
-	}
-	return h.(bcrypt.ALG_HANDLE), nil
 }
 
 // TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil,


### PR DESCRIPTION
`loadOrStoreAlg` is a bit cumbersome to use because it requires the caller to cast the return value to the correct type and handle the errors.

This PR updates `loadOrStoreAlg` so that callers don't have to type-cast the returned value nor handle the error by using type parameters.