### PR TITLE
Use bytes.Clone instead of manual cloning

### DIFF
--- a/cng/aes.go
+++ b/cng/aes.go
@@ -7,6 +7,7 @@
 package cng
 
 import (
+	"bytes"
 	"crypto/cipher"
 	"errors"
 	"runtime"
@@ -28,8 +29,7 @@ func NewAESCipher(key []byte) (cipher.Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &aesCipher{kh: kh, key: make([]byte, len(key))}
-	copy(c.key, key)
+	c := &aesCipher{kh: kh, key: bytes.Clone(key)}
 	runtime.SetFinalizer(c, (*aesCipher).finalize)
 	return c, nil
 }

--- a/cng/des.go
+++ b/cng/des.go
@@ -7,6 +7,7 @@
 package cng
 
 import (
+	"bytes"
 	"crypto/cipher"
 	"runtime"
 
@@ -27,8 +28,7 @@ func NewDESCipher(key []byte) (cipher.Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &desCipher{kh: kh, alg: bcrypt.DES_ALGORITHM, key: make([]byte, len(key))}
-	copy(c.key, key)
+	c := &desCipher{kh: kh, alg: bcrypt.DES_ALGORITHM, key: bytes.Clone(key)}
 	runtime.SetFinalizer(c, (*desCipher).finalize)
 	return c, nil
 }
@@ -38,8 +38,7 @@ func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &desCipher{kh: kh, alg: bcrypt.DES3_ALGORITHM, key: make([]byte, len(key))}
-	copy(c.key, key)
+	c := &desCipher{kh: kh, alg: bcrypt.DES3_ALGORITHM, key: bytes.Clone(key)}
 	runtime.SetFinalizer(c, (*desCipher).finalize)
 	return c, nil
 }

--- a/cng/hash.go
+++ b/cng/hash.go
@@ -195,11 +195,7 @@ func newHashX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *hashX 
 	if err != nil {
 		panic(err)
 	}
-	h := new(hashX)
-	h.alg = alg
-	if len(key) > 0 {
-		h.key = bytes.Clone(key)
-	}
+	h := &hashX{alg: alg, key: bytes.Clone(key)}
 	// Don't allocate hx.buf nor call bcrypt.CreateHash yet,
 	// which would be wasteful if the caller only wants to know
 	// the hash type. This is a common pattern in this package,
@@ -227,12 +223,7 @@ func (h *hashX) withCtx(fn func(ctx bcrypt.HASH_HANDLE) error) error {
 }
 
 func (h *hashX) Clone() (hash.Hash, error) {
-	h2 := &hashX{
-		alg: h.alg,
-	}
-	if h.key != nil {
-		h2.key = bytes.Clone(h.key)
-	}
+	h2 := &hashX{alg: h.alg, key: bytes.Clone(h.key)}
 	err := h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
 		return bcrypt.DuplicateHash(ctx, &h2._ctx, nil, 0)
 	})

--- a/cng/hash.go
+++ b/cng/hash.go
@@ -7,6 +7,7 @@
 package cng
 
 import (
+	"bytes"
 	"crypto"
 	"hash"
 	"runtime"
@@ -197,8 +198,7 @@ func newHashX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *hashX 
 	h := new(hashX)
 	h.alg = alg
 	if len(key) > 0 {
-		h.key = make([]byte, len(key))
-		copy(h.key, key)
+		h.key = bytes.Clone(key)
 	}
 	// Don't allocate hx.buf nor call bcrypt.CreateHash yet,
 	// which would be wasteful if the caller only wants to know
@@ -231,8 +231,7 @@ func (h *hashX) Clone() (hash.Hash, error) {
 		alg: h.alg,
 	}
 	if h.key != nil {
-		h2.key = make([]byte, len(h.key))
-		copy(h2.key, h.key)
+		h2.key = bytes.Clone(h.key)
 	}
 	err := h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
 		return bcrypt.DuplicateHash(ctx, &h2._ctx, nil, 0)


### PR DESCRIPTION
Use [bytes.Clone](https://pkg.go.dev/bytes#Clone) instead of manual cloning bytes slices. This reduce potential bugs when refactoring the code and makes the code cleaner.

`bytes.Clone` wasn't used before because it was introduced in Go 1.20, and we just bump our minimum version from Go 1.17 to Go 1.20.