### PR TITLE
Update RSA invalid salt length error message

### DIFF
--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -315,7 +315,7 @@ func newPSS_PADDING_INFO(h crypto.Hash, sizeBits uint32, saltLen int, sign bool)
 
 	// A salt length of -1 and 0 are valid Go sentinel values.
 	if saltLen <= -2 {
-		return info, errors.New("crypto/rsa: PSSOptions.SaltLength cannot be negative")
+		return info, errors.New("crypto/rsa: invalid PSS salt length")
 	}
 	// CNG does not support salt length special cases like Go crypto does,
 	// so we do a best-effort to resolve them.


### PR DESCRIPTION
Upstream just reworded the error message displayed when an invalid salt length is provided for RSA PSS ([source](https://github.com/golang/go/commit/93fcd8fb1882b55b3456aa753d32a2cf3d369b1c#diff-5add5ff057b0d06bb595f45e3e074652af0565974e8b2bb8022b27583295ae81L255)). That error message is used in an upstream test, so we need to follow suite.