### PR TITLE
Support PKCS1 with MD5SHA1

### DIFF
--- a/cng/rsa_test.go
+++ b/cng/rsa_test.go
@@ -217,6 +217,16 @@ func TestVerifyPKCS1v15_NotHashed(t *testing.T) {
 	}
 }
 
+func TestSignPKCS1v15_Empty(t *testing.T) {
+	priv, _ := newRSAKey(t, 2048)
+	_, err := cng.SignRSAPKCS1v15(priv, crypto.SHA256, nil)
+	if err == nil {
+		t.Fatal("error expected")
+	} else if err.Error() != "crypto/rsa: input must be hashed message" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
 	sha256 := cng.NewSHA256()
 	msg := []byte("hi!")


### PR DESCRIPTION
The MD5SHA1 hash is not supported by CNG, but the `AlgId` field is only used to pad the signature with the hash OID, and PKCS1 has historically used a null OID for MD5SHA1.

This is a special case for compatibility with TLS 1.0/1.1. We were previously falling back to Go crypto.

While here, add a check that verifies the length of the hashed message is correct for the given hash function. This was previously done by CNG, but CNG won't check this property for MD5SHA1 digests, so we need to do it ourselves. It is also a nice usability improvement, as we now return the same error message as upstream for this error condition.