### PR TITLE
Simplify GenerateKeyDSA

### DIFF
--- a/cng/dsa.go
+++ b/cng/dsa.go
@@ -455,7 +455,7 @@ func hashAlgFromGroup(groupSize int) bcrypt.HASHALGORITHM_ENUM {
 	switch groupSize {
 	case 20:
 		return bcrypt.DSA_HASH_ALGORITHM_SHA1
-	case 28, 32:
+	case 32:
 		return bcrypt.DSA_HASH_ALGORITHM_SHA256
 	case 64:
 		return bcrypt.DSA_HASH_ALGORITHM_SHA512

--- a/cng/dsa.go
+++ b/cng/dsa.go
@@ -284,7 +284,7 @@ func encodeDSAKey(h bcrypt.ALG_HANDLE, params DSAParameters, X, Y BigInt) (bcryp
 		copy(blob, (*(*[sizeOfDSAV2BlobHeader]byte)(unsafe.Pointer(&hdr)))[:])
 		data := blob[sizeOfDSAV2BlobHeader:]
 		if err := encodeBigInt(data, []sizedBigInt{
-			{dsaSeedNil[:groupSize], groupSize},
+			{dsaSeedNil[:], groupSize},
 			{params.Q, groupSize},
 			{params.P, keySize},
 			{params.G, keySize},

--- a/cng/dsa_test.go
+++ b/cng/dsa_test.go
@@ -130,27 +130,6 @@ func TestDSASignAndVerify(t *testing.T) {
 	testDSASignAndVerify(t, 0, priv)
 }
 
-func TestDSASignAndVerify224(t *testing.T) {
-	var gparams dsa.Parameters
-	err := dsa.GenerateParameters(&gparams, cng.RandReader, dsa.L2048N224)
-	if err != nil {
-		t.Fatalf("error generating parameters: %s", err)
-	}
-	params := cng.DSAParameters{
-		P: bbig.Enc(gparams.P),
-		Q: bbig.Enc(gparams.Q),
-		G: bbig.Enc(gparams.G),
-	}
-	X := bbig.Enc(fromHex("5078D4D29795CBE76D3AACFE48C9AF0BCDBEE91A"))
-	Y := bbig.Enc(fromHex("32969E5780CFE1C849A1C276D7AEB4F38A23B591739AA2FE197349AEEBD31366AEE5EB7E6C6DDB7C57D02432B30DB5AA66D9884299FAA72568944E4EEDC92EA3FBC6F39F53412FBCC563208F7C15B737AC8910DBC2D9C9B8C001E72FDC40EB694AB1F06A5A2DBD18D9E36C66F31F566742F11EC0A52E9F7B89355C02FB5D32D2"))
-	priv, err := cng.NewPrivateKeyDSA(params, X, Y)
-	if err != nil {
-		t.Fatalf("error generating key: %s", err)
-	}
-
-	testDSASignAndVerify(t, 0, priv)
-}
-
 func TestDSANewPublicKeyWithBadPublicKey(t *testing.T) {
 	params := cng.DSAParameters{
 		P: bbig.Enc(fromHex("A9B5B793FB4785793D246BAE77E8FF63CA52F442DA763C440259919FE1BC1D6065A9350637A04F75A2F039401D49F08E066C4D275A5A65DA5684BC563C14289D7AB8A67163BFBF79D85972619AD2CFF55AB0EE77A9002B0EF96293BDD0F42685EBB2C66C327079F6C98000FBCB79AACDE1BC6F9D5C7B1A97E3D9D54ED7951FEF")),


### PR DESCRIPTION
There is no need for `GenerateKeyDSA` to return a `PrivateKeyDSA` object, as crypto/dsa is only interested in the x and y components.

While here, rename `GenerateDSAParameters` to `GenerateParametersDSA`.