### PR TITLE
Add build tag to ntstatus.go

### DIFF
--- a/internal/bcrypt/ntstatus_windows.go
+++ b/internal/bcrypt/ntstatus_windows.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package bcrypt
 
 import (


### PR DESCRIPTION
This pull request includes a renaming of the `internal/bcrypt/ntstatus.go` file to `internal/bcrypt/ntstatus_windows.go` and updates the file's content to include the Microsoft Corporation copyright.