### PR TITLE
Add tests for confirming struct and oneshot hashes are not allocating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
         venv: [windows-2019, windows-2022]
         fips: [1, 0]
     runs-on: ${{ matrix.venv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x]
         venv: [windows-2019, windows-2022]
         fips: [1, 0]
     runs-on: ${{ matrix.venv }}

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -181,6 +181,66 @@ func TestHash_OneShot(t *testing.T) {
 	}
 }
 
+func TestHashAllocations(t *testing.T) {
+	msg := []byte("testing")
+	n := int(testing.AllocsPerRun(10, func() {
+		sink ^= cng.SHA1(msg)[0]
+		sink ^= cng.SHA256(msg)[0]
+		sink ^= cng.SHA384(msg)[0]
+		sink ^= cng.SHA512(msg)[0]
+		sink ^= cng.SumSHA3_256(msg)[0]
+		sink ^= cng.SumSHA3_384(msg)[0]
+		sink ^= cng.SumSHA3_512(msg)[0]
+	}))
+	want := 0
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
+func TestHashStructAllocations(t *testing.T) {
+	msg := []byte("testing")
+
+	sha1Hash := cng.NewSHA1()
+	sha256Hash := cng.NewSHA256()
+	sha384Hash := cng.NewSHA384()
+	sha512Hash := cng.NewSHA512()
+	sha3_256 := cng.NewSHA3_256()
+	sha3_384 := cng.NewSHA3_384()
+	sha3_512 := cng.NewSHA3_512()
+
+	sum := make([]byte, sha512Hash.Size())
+	n := int(testing.AllocsPerRun(10, func() {
+		sha1Hash.Write(msg)
+		sha256Hash.Write(msg)
+		sha384Hash.Write(msg)
+		sha512Hash.Write(msg)
+		sha3_256.Write(msg)
+		sha3_384.Write(msg)
+		sha3_512.Write(msg)
+
+		sha1Hash.Sum(sum[:0])
+		sha256Hash.Sum(sum[:0])
+		sha384Hash.Sum(sum[:0])
+		sha512Hash.Sum(sum[:0])
+		sha3_256.Sum(sum[:0])
+		sha3_384.Sum(sum[:0])
+		sha3_512.Sum(sum[:0])
+
+		sha1Hash.Reset()
+		sha256Hash.Reset()
+		sha384Hash.Reset()
+		sha512Hash.Reset()
+		sha3_256.Reset()
+		sha3_384.Reset()
+		sha3_512.Reset()
+	}))
+	want := 0
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
 func BenchmarkSHA256_8Bytes(b *testing.B) {
 	b.StopTimer()
 	h := cng.NewSHA256()

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -188,9 +188,6 @@ func TestHashAllocations(t *testing.T) {
 		sink ^= cng.SHA256(msg)[0]
 		sink ^= cng.SHA384(msg)[0]
 		sink ^= cng.SHA512(msg)[0]
-		sink ^= cng.SumSHA3_256(msg)[0]
-		sink ^= cng.SumSHA3_384(msg)[0]
-		sink ^= cng.SumSHA3_512(msg)[0]
 	}))
 	want := 0
 	if n > want {
@@ -205,9 +202,6 @@ func TestHashStructAllocations(t *testing.T) {
 	sha256Hash := cng.NewSHA256()
 	sha384Hash := cng.NewSHA384()
 	sha512Hash := cng.NewSHA512()
-	sha3_256 := cng.NewSHA3_256()
-	sha3_384 := cng.NewSHA3_384()
-	sha3_512 := cng.NewSHA3_512()
 
 	sum := make([]byte, sha512Hash.Size())
 	n := int(testing.AllocsPerRun(10, func() {
@@ -215,25 +209,16 @@ func TestHashStructAllocations(t *testing.T) {
 		sha256Hash.Write(msg)
 		sha384Hash.Write(msg)
 		sha512Hash.Write(msg)
-		sha3_256.Write(msg)
-		sha3_384.Write(msg)
-		sha3_512.Write(msg)
 
 		sha1Hash.Sum(sum[:0])
 		sha256Hash.Sum(sum[:0])
 		sha384Hash.Sum(sum[:0])
 		sha512Hash.Sum(sum[:0])
-		sha3_256.Sum(sum[:0])
-		sha3_384.Sum(sum[:0])
-		sha3_512.Sum(sum[:0])
 
 		sha1Hash.Reset()
 		sha256Hash.Reset()
 		sha384Hash.Reset()
 		sha512Hash.Reset()
-		sha3_256.Reset()
-		sha3_384.Reset()
-		sha3_512.Reset()
 	}))
 	want := 0
 	if n > want {

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -184,6 +184,8 @@ func TestHash_OneShot(t *testing.T) {
 func TestHashAllocations(t *testing.T) {
 	msg := []byte("testing")
 	n := int(testing.AllocsPerRun(10, func() {
+		sink ^= cng.MD4(msg)[0]
+		sink ^= cng.MD5(msg)[0]
 		sink ^= cng.SHA1(msg)[0]
 		sink ^= cng.SHA256(msg)[0]
 		sink ^= cng.SHA384(msg)[0]
@@ -198,6 +200,8 @@ func TestHashAllocations(t *testing.T) {
 func TestHashStructAllocations(t *testing.T) {
 	msg := []byte("testing")
 
+	md4Hash := cng.NewMD4()
+	md5Hash := cng.NewMD5()
 	sha1Hash := cng.NewSHA1()
 	sha256Hash := cng.NewSHA256()
 	sha384Hash := cng.NewSHA384()
@@ -205,16 +209,22 @@ func TestHashStructAllocations(t *testing.T) {
 
 	sum := make([]byte, sha512Hash.Size())
 	n := int(testing.AllocsPerRun(10, func() {
+		md4Hash.Write(msg)
+		md5Hash.Write(msg)
 		sha1Hash.Write(msg)
 		sha256Hash.Write(msg)
 		sha384Hash.Write(msg)
 		sha512Hash.Write(msg)
 
+		md4Hash.Sum(sum[:0])
+		md5Hash.Sum(sum[:0])
 		sha1Hash.Sum(sum[:0])
 		sha256Hash.Sum(sum[:0])
 		sha384Hash.Sum(sum[:0])
 		sha512Hash.Sum(sum[:0])
 
+		md4Hash.Reset()
+		md5Hash.Reset()
 		sha1Hash.Reset()
 		sha256Hash.Reset()
 		sha384Hash.Reset()


### PR DESCRIPTION
Add tests for confirming struct and oneshot hashes are not allocating, also removed 1.22.x from test matrix and added 1.24.x.