### PR TITLE
Add hash.Clone interface for HMAC and Hash

### DIFF
--- a/cng/hash.go
+++ b/cng/hash.go
@@ -160,7 +160,7 @@ type cloneHash interface {
 }
 
 var _ hash.Hash = (*hashX)(nil)
-var _ cloneHash = (*hashX)(nil)
+var _ HashCloner = (*hashX)(nil)
 
 // hashX implements [hash.Hash].
 type hashX struct {
@@ -201,14 +201,14 @@ func (h *hashX) init() {
 	runtime.SetFinalizer(h, (*hashX).finalize)
 }
 
-func (h *hashX) Clone() hash.Hash {
+func (h *hashX) Clone() (HashCloner, error) {
 	defer runtime.KeepAlive(h)
 	h2 := &hashX{alg: h.alg, key: bytes.Clone(h.key)}
 	if h.ctx != 0 {
 		hashClone(h.ctx, &h2.ctx)
 		runtime.SetFinalizer(h2, (*hashX).finalize)
 	}
-	return h2
+	return h2, nil
 }
 
 func (h *hashX) Reset() {

--- a/cng/hash.go
+++ b/cng/hash.go
@@ -149,16 +149,6 @@ func hashToID(h hash.Hash) string {
 	return hx.alg.id
 }
 
-// cloneHash is an interface that defines a Clone method.
-//
-// hash.CloneHash will probably be added in Go 1.25, see https://golang.org/issue/69521,
-// but we need it now.
-type cloneHash interface {
-	hash.Hash
-	// Clone returns a separate Hash instance with the same state as h.
-	Clone() hash.Hash
-}
-
 var _ hash.Hash = (*hashX)(nil)
 var _ HashCloner = (*hashX)(nil)
 

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -79,18 +79,6 @@ func TestHash(t *testing.T) {
 				t.Error("Write didn't change internal hash state")
 			}
 
-			h2 := h.(interface{ Clone() hash.Hash }).Clone()
-			h.Write(msg)
-			h2.Write(msg)
-			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", tt.String(), msg, actual, actual2)
-			}
-			h.Reset()
-			sum = h.Sum(nil)
-			if !bytes.Equal(sum, initSum) {
-				t.Errorf("got:%x want:%x", sum, initSum)
-			}
-
 			bw := h.(io.ByteWriter)
 			for i := 0; i < len(msg); i++ {
 				bw.WriteByte(msg[i])

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -302,7 +302,7 @@ func BenchmarkSHA256_OneShot(b *testing.B) {
 	}
 }
 
-// Helper function for writing. Verifies that Write does not error.Add commentMore actions
+// Helper function for writing. Verifies that Write does not error.
 func writeToHash(t *testing.T, h hash.Hash, p []byte) {
 	t.Helper()
 

--- a/cng/hashclone.go
+++ b/cng/hashclone.go
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package cng
+
+import (
+	"hash"
+)
+
+// HashCloner is an interface that defines a Clone method.
+type HashCloner interface {
+	hash.Hash
+	// Clone returns a separate Hash instance with the same state as h.
+	Clone() (HashCloner, error)
+}

--- a/cng/hashclone_go125.go
+++ b/cng/hashclone_go125.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build go1.25 && windows
+// +build go1.25,windows
+
+package cng
+
+import (
+	"hash"
+)
+
+type HashCloner = hash.Cloner

--- a/cng/sha3.go
+++ b/cng/sha3.go
@@ -76,7 +76,7 @@ func SupportsSHAKE(securityBits int) bool {
 }
 
 var _ hash.Hash = (*DigestSHA3)(nil)
-var _ cloneHash = (*DigestSHA3)(nil)
+var _ HashCloner = (*DigestSHA3)(nil)
 
 // DigestSHA3 is the [sha3.SHA3] implementation using the CNG API.
 type DigestSHA3 struct {
@@ -115,14 +115,14 @@ func (h *DigestSHA3) init() {
 	runtime.SetFinalizer(h, (*DigestSHA3).finalize)
 }
 
-func (h *DigestSHA3) Clone() hash.Hash {
+func (h *DigestSHA3) Clone() (HashCloner, error) {
 	defer runtime.KeepAlive(h)
 	h2 := &DigestSHA3{alg: h.alg}
 	if h.ctx != 0 {
 		hashClone(h.ctx, &h2.ctx)
 		runtime.SetFinalizer(h2, (*DigestSHA3).finalize)
 	}
-	return h2
+	return h2, nil
 }
 
 func (h *DigestSHA3) Reset() {


### PR DESCRIPTION
This PR implements upcoming hash.Clone interface on HMAC and hashes for keeping hash.Hash returns compatible with Go 1.25.