### PR TITLE
codeql: flag cryptotest as test data and add justification for [SM04391]

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  tests:
+    - "internal/cryptotest/*.go"

--- a/cng/aes.go
+++ b/cng/aes.go
@@ -105,10 +105,10 @@ func (c *aesCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
 	}
 	// Fall back to standard library for GCM with non-standard nonce or tag size.
 	if nonceSize != gcmStandardNonceSize {
-		return cipher.NewGCMWithNonceSize(&noGCM{c}, nonceSize)
+		return cipher.NewGCMWithNonceSize(&noGCM{c}, nonceSize) // CodeQL [SM04391] This is to keep compatibility with upstream, it's on end user teams to raise exceptions with the Crypto Board.
 	}
 	if tagSize != gcmTagSize {
-		return cipher.NewGCMWithTagSize(&noGCM{c}, tagSize)
+		return cipher.NewGCMWithTagSize(&noGCM{c}, tagSize) // CodeQL [SM04391] This is to keep compatibility with upstream, it's on end user teams to raise exceptions with the Crypto Board.
 	}
 	return newGCM(c.key, cipherGCMTLSNone)
 }


### PR DESCRIPTION
Resolving CodeQL errors in the GH UI is not enough to remove them from the s360 dashboard. We need to actually classify non-prod data