### PR TITLE
Add exclamation mark for versions less than Go 1.25

### DIFF
--- a/cng/hashclone.go
+++ b/cng/hashclone.go
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build windows
-// +build windows
+//go:build !go1.25 && windows
+// +build !go1.25,windows
 
 package cng
 


### PR DESCRIPTION
This pull request updates the build constraint in the hashclone.go file to ensure compatibility with Go versions earlier than 1.25.