### PR TITLE
Wrap HMAC with HMAC wrapper for skipping extra method checks

### DIFF
--- a/cng/hmac.go
+++ b/cng/hmac.go
@@ -31,5 +31,30 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		ch.Write(key)
 		key = ch.Sum(nil)
 	}
-	return newHashX(id, bcrypt.ALG_HANDLE_HMAC_FLAG, key)
+
+	return hmacWrapper{hashX: newHashX(id, bcrypt.ALG_HANDLE_HMAC_FLAG, key)}
+}
+
+type hmacWrapper struct {
+	hashX *hashX
+}
+
+func (h hmacWrapper) Write(p []byte) (n int, err error) {
+	return h.hashX.Write(p)
+}
+
+func (h hmacWrapper) Sum(b []byte) []byte {
+	return h.hashX.Sum(b)
+}
+
+func (h hmacWrapper) Reset() {
+	h.hashX.Reset()
+}
+
+func (h hmacWrapper) Size() int {
+	return h.hashX.Size()
+}
+
+func (h hmacWrapper) BlockSize() int {
+	return h.hashX.BlockSize()
 }


### PR DESCRIPTION
HMAC and hashes are using same underlying data struct in winnative. It is causing errors because mainstream golang is checking structs for additional methods. For crypto structs it is not enough to just implement an interface, but also given struct shouldn't have any additional methods. This PR fixes that with enwrapping hashX struct for HMAC.