### PR TITLE
Keep HMAC compatible with HashCloner interface

### DIFF
--- a/cng/hmac.go
+++ b/cng/hmac.go
@@ -58,3 +58,11 @@ func (h hmacWrapper) Size() int {
 func (h hmacWrapper) BlockSize() int {
 	return h.hashX.BlockSize()
 }
+
+func (h hmacWrapper) Clone() (HashCloner, error) {
+	clone, err := h.hashX.Clone()
+	if err != nil {
+		return nil, err
+	}
+	return hmacWrapper{hashX: clone.(*hashX)}, nil
+}


### PR DESCRIPTION
Golang 1.25 requires HMAC to be compatible with hash.Cloner interface. I added Clone method back to HMAC wrapper struct.