### PR TITLE
Wrap hash state not marshallable errors with ErrUnsupported.

### DIFF
--- a/cng/hash.go
+++ b/cng/hash.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto"
 	"errors"
-	"fmt"
 	"hash"
 	"runtime"
 	"unsafe"
@@ -242,16 +241,26 @@ func (h *hashX) BlockSize() int {
 	return int(h.alg.blockSize)
 }
 
+type errMarshallUnsupported struct{}
+
+func (e errMarshallUnsupported) Error() string {
+	return "cryptokit: hash state is not marshallable"
+}
+
+func (e errMarshallUnsupported) Unwrap() error {
+	return errors.ErrUnsupported
+}
+
 func (hx *hashX) MarshalBinary() ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (hx *hashX) AppendBinary(b []byte) ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (hx *hashX) UnmarshalBinary(data []byte) error {
-	return fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return errMarshallUnsupported{}
 }
 
 // hashData writes p to ctx. It panics on error.

--- a/cng/sha3.go
+++ b/cng/sha3.go
@@ -7,8 +7,6 @@
 package cng
 
 import (
-	"errors"
-	"fmt"
 	"hash"
 	"runtime"
 	"unsafe"
@@ -167,15 +165,15 @@ func (h *DigestSHA3) BlockSize() int {
 }
 
 func (ds *DigestSHA3) MarshalBinary() ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (ds *DigestSHA3) AppendBinary(b []byte) ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (ds *DigestSHA3) UnmarshalBinary(data []byte) error {
-	return fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return errMarshallUnsupported{}
 }
 
 // NewSHA3_256 returns a new SHA256 hash.
@@ -300,13 +298,13 @@ func (s *SHAKE) BlockSize() int {
 }
 
 func (s *SHAKE) MarshalBinary() ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (s *SHAKE) AppendBinary(b []byte) ([]byte, error) {
-	return nil, fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return nil, errMarshallUnsupported{}
 }
 
 func (s *SHAKE) UnmarshalBinary(data []byte) error {
-	return fmt.Errorf("cng: hash state is not marshallable: %w", errors.ErrUnsupported)
+	return errMarshallUnsupported{}
 }


### PR DESCRIPTION
This pull request refactors error handling in the CNG package to provide easier to assert error messages by wrapping errors with additional context using errors.ErrUnsupported. It also includes minor import adjustments in the affected files.
This PR addresses one of the steps of: https://github.com/microsoft/go/issues/1683