### PR TITLE
Add reusable line endings check workflow

### DIFF
--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   check-line-endings:
-    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@main
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@944d1d054c1265bf35b6632d42682217330907c4 # main

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -1,0 +1,14 @@
+name: Check Line Endings
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  check-line-endings:
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@main


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically check line endings on pushes and pull requests to the `main` branch.

CI/CD workflow addition:

* Added a `.github/workflows/check-line-endings.yml` workflow that leverages Microsoft's shared `check-line-endings.yml` to ensure consistent line endings in the repository.