### PR TITLE
Add benchmark workflow using shared go-infra reusable workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -88,14 +88,14 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@afe5d5b790efe90fd4531a895b4d4ba034280318
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@7ae6224604e62c88b95d8647cb391d8a2d1635a5
         with:
           artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
     permissions:
       actions: read
       contents: read
@@ -104,4 +104,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: afe5d5b790efe90fd4531a895b4d4ba034280318
+      infra-ref: 7ae6224604e62c88b95d8647cb391d8a2d1635a5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -88,14 +88,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
         with:
           artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
+          infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@7ae6224604e62c88b95d8647cb391d8a2d1635a5
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
     permissions:
       actions: read
       contents: read
@@ -104,4 +105,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 7ae6224604e62c88b95d8647cb391d8a2d1635a5
+      infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Benchmark
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'Base ref to compare against (branch, tag, or SHA)'
+        required: true
+        default: 'main'
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Pinned to the SHA of the add-benchcheck-and-benchmark-workflows branch in
+# microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
+jobs:
+  setup:
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    with:
+      default-base-ref: main
+      dispatch-base-ref: ${{ inputs.base-ref }}
+
+  bench:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.25, 1.26]
+        venv: [windows-2022, windows-2025, windows-11-arm]
+        fips: [0, 1]
+    name: bench (${{ matrix.venv }}, fips${{ matrix.fips }}, go${{ matrix.go-version }})
+    runs-on: ${{ matrix.venv }}
+    steps:
+      - name: Initialize status
+        shell: bash
+        run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to upstream.
+          go-download-base-url: ${{ (matrix.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
+
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.head-ref }}
+          path: head
+
+      - name: Checkout BASE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.base-ref }}
+          path: base
+
+      - name: Set FIPS mode
+        shell: cmd
+        run: REG ADD HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /f /d ${{ matrix.fips }}
+
+      - name: Run benchmarks (base)
+        shell: bash
+        working-directory: base
+        env:
+          MS_GO_NOSYSTEMCRYPTO: "1"
+          GO_TEST_FIPS: ${{ matrix.fips }}
+        run: |
+          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
+
+      - name: Run benchmarks (head)
+        shell: bash
+        working-directory: head
+        env:
+          MS_GO_NOSYSTEMCRYPTO: "1"
+          GO_TEST_FIPS: ${{ matrix.fips }}
+        run: |
+          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
+
+      - name: "Compare and check"
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+        with:
+          artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
+
+  conclusion:
+    needs: [setup, bench]
+    if: always() && needs.setup.result == 'success'
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    with:
+      head-ref: ${{ needs.setup.outputs.head-ref }}
+      pr-number: ${{ needs.setup.outputs.pr-number }}
+      bench-result: ${{ needs.bench.result }}
+      infra-ref: f321d14481eb6b81bf7d36700a34c6cfc2434ae2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,46 +23,34 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Pinned to the SHA of the add-benchcheck-and-benchmark-workflows branch in
+# Pinned to the SHA of the add-benchmark-workflow branch in
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
-  setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
-    with:
-      default-base-ref: main
-      dispatch-base-ref: ${{ inputs.base-ref }}
-
-  bench:
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.25, 1.26]
-        venv: [windows-2022, windows-2025, windows-11-arm]
-        fips: [0, 1]
-    name: bench (${{ matrix.venv }}, fips${{ matrix.fips }}, go${{ matrix.go-version }})
-    uses: microsoft/go-infra/.github/workflows/benchmark-run.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
-    with:
-      runs-on: ${{ matrix.venv }}
-      go-version: ${{ matrix.go-version }}
-      # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to upstream.
-      go-download-base-url: ${{ (matrix.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
-      head-ref: ${{ needs.setup.outputs.head-ref }}
-      base-ref: ${{ needs.setup.outputs.base-ref }}
-      artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
-      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
-      fips-mode: ${{ matrix.fips }}
-
-  conclusion:
-    needs: [setup, bench]
-    if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
+  benchmark:
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@990af0e5fc05600480d042f3aee26298e1924c86
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
-      head-ref: ${{ needs.setup.outputs.head-ref }}
-      pr-number: ${{ needs.setup.outputs.pr-number }}
-      bench-result: ${{ needs.bench.result }}
-      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
+      default-base-ref: main
+      dispatch-base-ref: ${{ inputs.base-ref }}
+      # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to
+      # upstream by pointing those cells at https://go.dev/dl/.
+      matrix: |
+        {
+          "include": [
+            { "label": "windows-2022-fips0-go1.25",   "runs-on": "windows-2022",   "go-version": "1.25", "fips-mode": "0" },
+            { "label": "windows-2022-fips1-go1.25",   "runs-on": "windows-2022",   "go-version": "1.25", "fips-mode": "1" },
+            { "label": "windows-2022-fips0-go1.26",   "runs-on": "windows-2022",   "go-version": "1.26", "fips-mode": "0" },
+            { "label": "windows-2022-fips1-go1.26",   "runs-on": "windows-2022",   "go-version": "1.26", "fips-mode": "1" },
+            { "label": "windows-2025-fips0-go1.25",   "runs-on": "windows-2025",   "go-version": "1.25", "fips-mode": "0" },
+            { "label": "windows-2025-fips1-go1.25",   "runs-on": "windows-2025",   "go-version": "1.25", "fips-mode": "1" },
+            { "label": "windows-2025-fips0-go1.26",   "runs-on": "windows-2025",   "go-version": "1.26", "fips-mode": "0" },
+            { "label": "windows-2025-fips1-go1.26",   "runs-on": "windows-2025",   "go-version": "1.26", "fips-mode": "1" },
+            { "label": "windows-11-arm-fips0-go1.25", "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "0", "go-download-base-url": "https://go.dev/dl/" },
+            { "label": "windows-11-arm-fips1-go1.25", "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "1", "go-download-base-url": "https://go.dev/dl/" },
+            { "label": "windows-11-arm-fips0-go1.26", "runs-on": "windows-11-arm", "go-version": "1.26", "fips-mode": "0" },
+            { "label": "windows-11-arm-fips1-go1.26", "runs-on": "windows-11-arm", "go-version": "1.26", "fips-mode": "1" }
+          ]
+        }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -88,14 +88,14 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@afe5d5b790efe90fd4531a895b4d4ba034280318
         with:
           artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@afe5d5b790efe90fd4531a895b4d4ba034280318
     permissions:
       actions: read
       contents: read
@@ -104,4 +104,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: f321d14481eb6b81bf7d36700a34c6cfc2434ae2
+      infra-ref: afe5d5b790efe90fd4531a895b4d4ba034280318

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -88,15 +88,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@30c731c9e1ac8b75b71632de29585b90e88d6cc3
         with:
           artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
-          infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+          infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
     permissions:
       actions: read
       contents: read
@@ -105,4 +105,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 4f764ef42aa73aaee0f9e0a573edf9ea78dafba0
+      infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,30 +27,25 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@990af0e5fc05600480d042f3aee26298e1924c86
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@6159d42301b70b81263c8c1c9f7091b0ddbe3b19
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
+      infra-ref: 6159d42301b70b81263c8c1c9f7091b0ddbe3b19
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
-      # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to
-      # upstream by pointing those cells at https://go.dev/dl/.
+      # Cross product of runs-on × go-version × fips-mode, with an `include`
+      # exception: there is no Microsoft build of Go 1.25 for Windows 11 ARM,
+      # so those cells fall back to upstream Go.
       matrix: |
         {
+          "runs-on": ["windows-2022", "windows-2025", "windows-11-arm"],
+          "go-version": ["1.25", "1.26"],
+          "fips-mode": ["0", "1"],
           "include": [
-            { "label": "windows-2022-fips0-go1.25",   "runs-on": "windows-2022",   "go-version": "1.25", "fips-mode": "0" },
-            { "label": "windows-2022-fips1-go1.25",   "runs-on": "windows-2022",   "go-version": "1.25", "fips-mode": "1" },
-            { "label": "windows-2022-fips0-go1.26",   "runs-on": "windows-2022",   "go-version": "1.26", "fips-mode": "0" },
-            { "label": "windows-2022-fips1-go1.26",   "runs-on": "windows-2022",   "go-version": "1.26", "fips-mode": "1" },
-            { "label": "windows-2025-fips0-go1.25",   "runs-on": "windows-2025",   "go-version": "1.25", "fips-mode": "0" },
-            { "label": "windows-2025-fips1-go1.25",   "runs-on": "windows-2025",   "go-version": "1.25", "fips-mode": "1" },
-            { "label": "windows-2025-fips0-go1.26",   "runs-on": "windows-2025",   "go-version": "1.26", "fips-mode": "0" },
-            { "label": "windows-2025-fips1-go1.26",   "runs-on": "windows-2025",   "go-version": "1.26", "fips-mode": "1" },
-            { "label": "windows-11-arm-fips0-go1.25", "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "0", "go-download-base-url": "https://go.dev/dl/" },
-            { "label": "windows-11-arm-fips1-go1.25", "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "1", "go-download-base-url": "https://go.dev/dl/" },
-            { "label": "windows-11-arm-fips0-go1.26", "runs-on": "windows-11-arm", "go-version": "1.26", "fips-mode": "0" },
-            { "label": "windows-11-arm-fips1-go1.26", "runs-on": "windows-11-arm", "go-version": "1.26", "fips-mode": "1" }
+            { "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "0", "go-download-base-url": "https://go.dev/dl/" },
+            { "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "1", "go-download-base-url": "https://go.dev/dl/" }
           ]
         }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,13 +27,12 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@6159d42301b70b81263c8c1c9f7091b0ddbe3b19
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@20f44911f27a3ec701312153cfc23cfa10155e50
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
-      infra-ref: 6159d42301b70b81263c8c1c9f7091b0ddbe3b19
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
       # Cross product of runs-on × go-version × fips-mode, with an `include`

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -88,15 +88,15 @@ jobs:
           go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
       - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4e55a96cf2ae064aab767674b96bf0512db7a5d8
         with:
           artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
-          infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
+          infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@30c731c9e1ac8b75b71632de29585b90e88d6cc3
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
     permissions:
       actions: read
       contents: read
@@ -105,4 +105,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 30c731c9e1ac8b75b71632de29585b90e88d6cc3
+      infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ concurrency:
 # microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   setup:
-    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-setup.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
     with:
       default-base-ref: main
       dispatch-base-ref: ${{ inputs.base-ref }}
@@ -41,62 +41,22 @@ jobs:
         venv: [windows-2022, windows-2025, windows-11-arm]
         fips: [0, 1]
     name: bench (${{ matrix.venv }}, fips${{ matrix.fips }}, go${{ matrix.go-version }})
-    runs-on: ${{ matrix.venv }}
-    steps:
-      - name: Initialize status
-        shell: bash
-        run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-          # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to upstream.
-          go-download-base-url: ${{ (matrix.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
-
-      - name: Checkout HEAD
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.setup.outputs.head-ref }}
-          path: head
-
-      - name: Checkout BASE
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.setup.outputs.base-ref }}
-          path: base
-
-      - name: Set FIPS mode
-        shell: cmd
-        run: REG ADD HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /f /d ${{ matrix.fips }}
-
-      - name: Run benchmarks (base)
-        shell: bash
-        working-directory: base
-        env:
-          MS_GO_NOSYSTEMCRYPTO: "1"
-          GO_TEST_FIPS: ${{ matrix.fips }}
-        run: |
-          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
-
-      - name: Run benchmarks (head)
-        shell: bash
-        working-directory: head
-        env:
-          MS_GO_NOSYSTEMCRYPTO: "1"
-          GO_TEST_FIPS: ${{ matrix.fips }}
-        run: |
-          go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
-
-      - name: "Compare and check"
-        uses: microsoft/go-infra/.github/actions/benchcheck-compare@4e55a96cf2ae064aab767674b96bf0512db7a5d8
-        with:
-          artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
-          infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-run.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
+    with:
+      runs-on: ${{ matrix.venv }}
+      go-version: ${{ matrix.go-version }}
+      # No Microsoft build of Go 1.25 for Windows 11 ARM; fall back to upstream.
+      go-download-base-url: ${{ (matrix.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
+      head-ref: ${{ needs.setup.outputs.head-ref }}
+      base-ref: ${{ needs.setup.outputs.base-ref }}
+      artifact-name: benchstat-${{ matrix.venv }}-fips${{ matrix.fips }}-go${{ matrix.go-version }}
+      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff
+      fips-mode: ${{ matrix.fips }}
 
   conclusion:
     needs: [setup, bench]
     if: always() && needs.setup.result == 'success'
-    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@4e55a96cf2ae064aab767674b96bf0512db7a5d8
+    uses: microsoft/go-infra/.github/workflows/benchmark-conclusion.yml@ac07251bf61c20b3ec1f090f519c546a7f9807ff
     permissions:
       actions: read
       contents: read
@@ -105,4 +65,4 @@ jobs:
       head-ref: ${{ needs.setup.outputs.head-ref }}
       pr-number: ${{ needs.setup.outputs.pr-number }}
       bench-result: ${{ needs.bench.result }}
-      infra-ref: 4e55a96cf2ae064aab767674b96bf0512db7a5d8
+      infra-ref: ac07251bf61c20b3ec1f090f519c546a7f9807ff

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,14 +35,13 @@ jobs:
       dispatch-base-ref: ${{ inputs.base-ref }}
       # Cross product of runs-on × go-version × fips-mode, with an `include`
       # exception: there is no Microsoft build of Go 1.25 for Windows 11 ARM,
-      # so those cells fall back to upstream Go.
+      # so those entries fall back to upstream Go.
       matrix: |
         {
           "runs-on": ["windows-2022", "windows-2025", "windows-11-arm"],
           "go-version": ["1.25", "1.26"],
           "fips-mode": ["0", "1"],
           "include": [
-            { "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "0", "go-download-base-url": "https://go.dev/dl/" },
-            { "runs-on": "windows-11-arm", "go-version": "1.25", "fips-mode": "1", "go-download-base-url": "https://go.dev/dl/" }
+            { "runs-on": "windows-11-arm", "go-version": "1.25", "go-download-base-url": "https://go.dev/dl/" }
           ]
         }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,11 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Pinned to the SHA of the add-benchmark-workflow branch in
-# microsoft/go-infra. Repin to the merge-commit SHA before merging this PR.
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@20f44911f27a3ec701312153cfc23cfa10155e50
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@5e6a5b28f97bcd009df177f658149009d29d1b1c # v0.0.11
     permissions:
       actions: read
       contents: read

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+<!-- trigger: add-benchmark-workflow -->

--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
-
-<!-- trigger: add-benchmark-workflow -->


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for benchmarking. The workflow is designed to run performance benchmarks automatically on pull requests and can also be triggered manually, supporting multiple Windows environments and Go versions.

**Benchmark workflow automation:**

* Added a new workflow file `.github/workflows/benchmark.yml` that runs benchmarks on pull requests and via manual dispatch, comparing the current changes against a specified base reference.
* Configured the workflow to test across multiple Windows environments (`windows-2022`, `windows-2025`, `windows-11-arm`), Go versions (`1.25`, `1.26`), and FIPS modes, including a fallback for Go 1.25 on Windows 11 ARM.
* Set up appropriate permissions and concurrency controls to ensure safe and efficient workflow execution.