### PR TITLE
Add CNG ML-DSA support

### DIFF
--- a/cng/mldsa.go
+++ b/cng/mldsa.go
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package cng
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+
+	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
+)
+
+const (
+	// privateKeySizeMLDSA is the size of an ML-DSA private key seed.
+	privateKeySizeMLDSA = 32
+
+	// publicKeySizeMLDSA44 is the size of an ML-DSA-44 public key encoding.
+	publicKeySizeMLDSA44 = 1312
+
+	// publicKeySizeMLDSA65 is the size of an ML-DSA-65 public key encoding.
+	publicKeySizeMLDSA65 = 1952
+
+	// publicKeySizeMLDSA87 is the size of an ML-DSA-87 public key encoding.
+	publicKeySizeMLDSA87 = 2592
+
+	// signatureSizeMLDSA44 is the size of an ML-DSA-44 signature.
+	signatureSizeMLDSA44 = 2420
+
+	// signatureSizeMLDSA65 is the size of an ML-DSA-65 signature.
+	signatureSizeMLDSA65 = 3309
+
+	// signatureSizeMLDSA87 is the size of an ML-DSA-87 signature.
+	signatureSizeMLDSA87 = 4627
+
+	sizeOfPQDSAKeyBlobHeader      = 12
+	maxMLDSAParameterSetNameBytes = 6
+	sizeOfPrivateSeedBlobMLDSA    = sizeOfPQDSAKeyBlobHeader + maxMLDSAParameterSetNameBytes + privateKeySizeMLDSA
+	sizeOfPublicKeyBlobMLDSA87    = sizeOfPQDSAKeyBlobHeader + maxMLDSAParameterSetNameBytes + publicKeySizeMLDSA87
+)
+
+type mldsaAlgorithm struct {
+	handle bcrypt.ALG_HANDLE
+}
+
+func loadMLDSA() (mldsaAlgorithm, error) {
+	return loadOrStoreAlg(bcrypt.MLDSA_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (mldsaAlgorithm, error) {
+		return mldsaAlgorithm{handle: h}, nil
+	})
+}
+
+// SupportsMLDSA returns true if ML-DSA is supported on this platform.
+func SupportsMLDSA() bool {
+	_, err := loadMLDSA()
+	return err == nil
+}
+
+func generateMLDSAKey(paramSet string, dst []byte) error {
+	alg, err := loadMLDSA()
+	if err != nil {
+		return err
+	}
+
+	var hKey bcrypt.KEY_HANDLE
+	if err := bcrypt.GenerateKeyPair(alg.handle, &hKey, 0, 0); err != nil {
+		return err
+	}
+	defer bcrypt.DestroyKey(hKey)
+
+	if err := setString(bcrypt.HANDLE(hKey), bcrypt.PARAMETER_SET_NAME, paramSet); err != nil {
+		return err
+	}
+	if err := bcrypt.FinalizeKeyPair(hKey, 0); err != nil {
+		return err
+	}
+
+	var blob [sizeOfPrivateSeedBlobMLDSA]byte
+	var size uint32
+	if err := bcrypt.ExportKey(hKey, 0, utf16PtrFromString(bcrypt.PQDSA_PRIVATE_SEED_BLOB), blob[:], &size, 0); err != nil {
+		return err
+	}
+	return extractPQDSAKeyBytes(dst, blob[:size])
+}
+
+func newPQDSAKeyBlob(dst []byte, paramSet string, keyBytes []byte, magic bcrypt.KeyBlobMagicNumber) ([]byte, error) {
+	paramSetByteLen := (len(paramSet) + 1) * 2
+	blobSize := 12 + paramSetByteLen + len(keyBytes)
+	if len(dst) < blobSize {
+		return nil, errors.New("mldsa: destination blob too small")
+	}
+	blob := dst[:blobSize]
+	putUint32LE(blob[0:4], uint32(magic))
+	putUint32LE(blob[4:8], uint32(paramSetByteLen))
+	putUint32LE(blob[8:12], uint32(len(keyBytes)))
+	for i := 0; i < len(paramSet); i++ {
+		if paramSet[i] == 0 || paramSet[i] > 127 {
+			panic("newPQDSAKeyBlob only supports ASCII parameter set names, got " + paramSet)
+		}
+		putUint16LE(blob[12+i*2:], uint16(paramSet[i]))
+	}
+	putUint16LE(blob[12+len(paramSet)*2:], 0)
+	copy(blob[12+paramSetByteLen:], keyBytes)
+	return blob, nil
+}
+
+func extractPQDSAKeyBytes(dst, blob []byte) error {
+	if len(blob) < 12 {
+		return errors.New("mldsa: blob too small")
+	}
+	cbParameterSet := getUint32LE(blob[4:8])
+	cbKey := getUint32LE(blob[8:12])
+	headerSize := 12 + int(cbParameterSet)
+	if len(blob) < headerSize+int(cbKey) {
+		return errors.New("mldsa: invalid blob size")
+	}
+	if len(dst) != int(cbKey) {
+		return errors.New("mldsa: destination size mismatch")
+	}
+	copy(dst, blob[headerSize:headerSize+int(cbKey)])
+	return nil
+}
+
+func importMLDSAPrivateKey(paramSet string, seed []byte) (bcrypt.KEY_HANDLE, error) {
+	alg, err := loadMLDSA()
+	if err != nil {
+		return 0, err
+	}
+	var blobBuf [sizeOfPrivateSeedBlobMLDSA]byte
+	blob, err := newPQDSAKeyBlob(blobBuf[:], paramSet, seed, bcrypt.MLDSA_PRIVATE_SEED_MAGIC)
+	if err != nil {
+		return 0, err
+	}
+	var hKey bcrypt.KEY_HANDLE
+	if err := bcrypt.ImportKeyPair(alg.handle, 0, utf16PtrFromString(bcrypt.PQDSA_PRIVATE_SEED_BLOB), &hKey, blob, 0); err != nil {
+		return 0, err
+	}
+	return hKey, nil
+}
+
+func importMLDSAPublicKey(paramSet string, publicKey []byte) (bcrypt.KEY_HANDLE, error) {
+	alg, err := loadMLDSA()
+	if err != nil {
+		return 0, err
+	}
+	var blobBuf [sizeOfPublicKeyBlobMLDSA87]byte
+	blob, err := newPQDSAKeyBlob(blobBuf[:], paramSet, publicKey, bcrypt.MLDSA_PUBLIC_MAGIC)
+	if err != nil {
+		return 0, err
+	}
+	var hKey bcrypt.KEY_HANDLE
+	if err := bcrypt.ImportKeyPair(alg.handle, 0, utf16PtrFromString(bcrypt.PQDSA_PUBLIC_BLOB), &hKey, blob, 0); err != nil {
+		return 0, err
+	}
+	return hKey, nil
+}
+
+func mldsaPublicKey(paramSet string, seed, dst []byte) error {
+	hKey, err := importMLDSAPrivateKey(paramSet, seed)
+	if err != nil {
+		return err
+	}
+	defer bcrypt.DestroyKey(hKey)
+
+	var blob [sizeOfPublicKeyBlobMLDSA87]byte
+	var size uint32
+	if err := bcrypt.ExportKey(hKey, 0, utf16PtrFromString(bcrypt.PQDSA_PUBLIC_BLOB), blob[:], &size, 0); err != nil {
+		return err
+	}
+	return extractPQDSAKeyBytes(dst, blob[:size])
+}
+
+func mldsaPadding(context string) (bcrypt.PQDSA_PADDING_INFO, []byte, bcrypt.PadMode, error) {
+	if len(context) > 255 {
+		return bcrypt.PQDSA_PADDING_INFO{}, nil, 0, errors.New("mldsa: context too long")
+	}
+	if context == "" {
+		return bcrypt.PQDSA_PADDING_INFO{}, nil, bcrypt.PAD_PQDSA, nil
+	}
+	contextBytes := []byte(context)
+	return bcrypt.PQDSA_PADDING_INFO{
+		Context:     &contextBytes[0],
+		ContextSize: uint32(len(contextBytes)),
+	}, contextBytes, bcrypt.PAD_PQDSA, nil
+}
+
+func mldsaSign(paramSet string, seed, message []byte, signatureSize int, context string) ([]byte, error) {
+	hKey, err := importMLDSAPrivateKey(paramSet, seed)
+	if err != nil {
+		return nil, err
+	}
+	defer bcrypt.DestroyKey(hKey)
+
+	info, contextBytes, flags, err := mldsaPadding(context)
+	if err != nil {
+		return nil, err
+	}
+	var infoPtr unsafe.Pointer
+	if flags != 0 {
+		infoPtr = unsafe.Pointer(&info)
+		defer runtime.KeepAlive(contextBytes)
+	}
+
+	signature := make([]byte, signatureSize)
+	var size uint32
+	if err := bcrypt.SignHash(hKey, infoPtr, message, signature, &size, flags); err != nil {
+		return nil, err
+	}
+	return signature[:size], nil
+}
+
+func mldsaSignExternalMu(paramSet string, seed, mu []byte, signatureSize int) ([]byte, error) {
+	if len(mu) != 64 {
+		return nil, errors.New("mldsa: invalid message hash length")
+	}
+	hKey, err := importMLDSAPrivateKey(paramSet, seed)
+	if err != nil {
+		return nil, err
+	}
+	defer bcrypt.DestroyKey(hKey)
+
+	signature := make([]byte, signatureSize)
+	var size uint32
+	if err := bcrypt.SignHash(hKey, nil, mu, signature, &size, bcrypt.MLDSA_EXTERNAL_MU); err != nil {
+		return nil, err
+	}
+	return signature[:size], nil
+}
+
+func mldsaVerify(paramSet string, publicKey, message, signature []byte, signatureSize int, context string) error {
+	if len(signature) != signatureSize {
+		return errors.New("mldsa: invalid signature length")
+	}
+	hKey, err := importMLDSAPublicKey(paramSet, publicKey)
+	if err != nil {
+		return err
+	}
+	defer bcrypt.DestroyKey(hKey)
+
+	info, contextBytes, flags, err := mldsaPadding(context)
+	if err != nil {
+		return err
+	}
+	var infoPtr unsafe.Pointer
+	if flags != 0 {
+		infoPtr = unsafe.Pointer(&info)
+		defer runtime.KeepAlive(contextBytes)
+	}
+	return bcrypt.VerifySignature(hKey, infoPtr, message, signature, flags)
+}
+
+func mldsaVerifyExternalMu(paramSet string, publicKey, mu, signature []byte, signatureSize int) error {
+	if len(mu) != 64 {
+		return errors.New("mldsa: invalid message hash length")
+	}
+	if len(signature) != signatureSize {
+		return errors.New("mldsa: invalid signature length")
+	}
+	hKey, err := importMLDSAPublicKey(paramSet, publicKey)
+	if err != nil {
+		return err
+	}
+	defer bcrypt.DestroyKey(hKey)
+	return bcrypt.VerifySignature(hKey, nil, mu, signature, bcrypt.MLDSA_EXTERNAL_MU)
+}
+
+// MLDSAParameters represents one of the fixed ML-DSA parameter sets.
+type MLDSAParameters struct {
+	name          string
+	paramSet      string
+	publicKeySize int
+	signatureSize int
+}
+
+var (
+	mldsa44 = MLDSAParameters{
+		name:          "ML-DSA-44",
+		paramSet:      bcrypt.MLDSA_PARAMETER_SET_44,
+		publicKeySize: publicKeySizeMLDSA44,
+		signatureSize: signatureSizeMLDSA44,
+	}
+	mldsa65 = MLDSAParameters{
+		name:          "ML-DSA-65",
+		paramSet:      bcrypt.MLDSA_PARAMETER_SET_65,
+		publicKeySize: publicKeySizeMLDSA65,
+		signatureSize: signatureSizeMLDSA65,
+	}
+	mldsa87 = MLDSAParameters{
+		name:          "ML-DSA-87",
+		paramSet:      bcrypt.MLDSA_PARAMETER_SET_87,
+		publicKeySize: publicKeySizeMLDSA87,
+		signatureSize: signatureSizeMLDSA87,
+	}
+)
+
+// MLDSA44 returns the ML-DSA-44 parameter set.
+func MLDSA44() MLDSAParameters { return mldsa44 }
+
+// MLDSA65 returns the ML-DSA-65 parameter set.
+func MLDSA65() MLDSAParameters { return mldsa65 }
+
+// MLDSA87 returns the ML-DSA-87 parameter set.
+func MLDSA87() MLDSAParameters { return mldsa87 }
+
+func (params MLDSAParameters) valid() bool {
+	switch params {
+	case mldsa44, mldsa65, mldsa87:
+		return true
+	default:
+		return false
+	}
+}
+
+// PublicKeySize returns the size of public keys for this parameter set, in bytes.
+func (params MLDSAParameters) PublicKeySize() int { return params.publicKeySize }
+
+// SignatureSize returns the size of signatures for this parameter set, in bytes.
+func (params MLDSAParameters) SignatureSize() int { return params.signatureSize }
+
+// String returns the name of the parameter set.
+func (params MLDSAParameters) String() string { return params.name }
+
+var errInvalidMLDSAParameters = errors.New("mldsa: invalid parameters")
+
+// PrivateKeyMLDSA is an ML-DSA private key seed.
+type PrivateKeyMLDSA struct {
+	params MLDSAParameters
+	seed   [privateKeySizeMLDSA]byte
+}
+
+// GenerateKeyMLDSA generates a new ML-DSA private key.
+func GenerateKeyMLDSA(params MLDSAParameters) (*PrivateKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	key := &PrivateKeyMLDSA{params: params}
+	if err := generateMLDSAKey(params.paramSet, key.seed[:]); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// NewPrivateKeyMLDSA constructs an ML-DSA private key from its seed.
+func NewPrivateKeyMLDSA(params MLDSAParameters, seed []byte) (*PrivateKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	if len(seed) != privateKeySizeMLDSA {
+		return nil, errors.New("mldsa: invalid private key size")
+	}
+	key := &PrivateKeyMLDSA{params: params}
+	copy(key.seed[:], seed)
+	return key, nil
+}
+
+// Bytes returns the private key seed.
+func (key *PrivateKeyMLDSA) Bytes() []byte {
+	return key.seed[:]
+}
+
+// Parameters returns the parameters associated with this private key.
+func (key *PrivateKeyMLDSA) Parameters() MLDSAParameters { return key.params }
+
+// PublicKey returns the corresponding public key.
+func (key *PrivateKeyMLDSA) PublicKey() *PublicKeyMLDSA {
+	publicKey := &PublicKeyMLDSA{params: key.params}
+	if err := mldsaPublicKey(key.params.paramSet, key.seed[:], publicKey.bytes[:key.params.publicKeySize]); err != nil {
+		panic(err)
+	}
+	return publicKey
+}
+
+// Sign signs message with context using ML-DSA.
+func (key *PrivateKeyMLDSA) Sign(message []byte, context string) ([]byte, error) {
+	return mldsaSign(key.params.paramSet, key.seed[:], message, key.params.signatureSize, context)
+}
+
+// SignExternalMu signs a pre-hashed mu message representative using ML-DSA.
+func (key *PrivateKeyMLDSA) SignExternalMu(mu []byte) ([]byte, error) {
+	return mldsaSignExternalMu(key.params.paramSet, key.seed[:], mu, key.params.signatureSize)
+}
+
+// PublicKeyMLDSA is an ML-DSA public key.
+type PublicKeyMLDSA struct {
+	params MLDSAParameters
+	bytes  [publicKeySizeMLDSA87]byte
+}
+
+// NewPublicKeyMLDSA constructs an ML-DSA public key from its encoding.
+func NewPublicKeyMLDSA(params MLDSAParameters, publicKey []byte) (*PublicKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	if len(publicKey) != params.publicKeySize {
+		return nil, errors.New("mldsa: invalid public key size")
+	}
+	if hKey, err := importMLDSAPublicKey(params.paramSet, publicKey); err != nil {
+		return nil, err
+	} else {
+		bcrypt.DestroyKey(hKey)
+	}
+	key := &PublicKeyMLDSA{params: params}
+	copy(key.bytes[:], publicKey)
+	return key, nil
+}
+
+// Bytes returns the public key encoding.
+func (key *PublicKeyMLDSA) Bytes() []byte {
+	return key.bytes[:key.params.publicKeySize]
+}
+
+// Parameters returns the parameters associated with this public key.
+func (key *PublicKeyMLDSA) Parameters() MLDSAParameters { return key.params }
+
+// Verify verifies an ML-DSA signature.
+func (key *PublicKeyMLDSA) Verify(message, signature []byte, context string) error {
+	return mldsaVerify(key.params.paramSet, key.bytes[:key.params.publicKeySize], message, signature, key.params.signatureSize, context)
+}
+
+// VerifyExternalMu verifies an ML-DSA signature over a pre-hashed mu message representative.
+func (key *PublicKeyMLDSA) VerifyExternalMu(mu, signature []byte) error {
+	return mldsaVerifyExternalMu(key.params.paramSet, key.bytes[:key.params.publicKeySize], mu, signature, key.params.signatureSize)
+}

--- a/cng/mldsa_test.go
+++ b/cng/mldsa_test.go
@@ -1,0 +1,412 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package cng_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/microsoft/go-crypto-winnative/cng"
+)
+
+type mldsaTestCase struct {
+	name string
+	seed string
+	msg  string
+}
+
+type mldsaExternalMuTestCase struct {
+	name   string
+	params cng.MLDSAParameters
+	seed   string
+	mu     string
+}
+
+var mldsaParameterTests = []struct {
+	name   string
+	params cng.MLDSAParameters
+}{
+	{"44", cng.MLDSA44()},
+	{"65", cng.MLDSA65()},
+	{"87", cng.MLDSA87()},
+}
+
+var mldsaACVPTestCases = []mldsaTestCase{
+	// From crypto/internal/fips140/mldsa/mldsa_test.go TestACVPRejectionKATs.
+	{"Path/ML-DSA-44/1", "5C624FCC1862452452D0C665840D8237F43108E5499EDCDC108FBC49D596E4B7", "951FDF5473A4CBA6D9E5B5DB7E79FB8173921BA5B13E9271401B8F907B8B7D5B"},
+	{"Path/ML-DSA-44/2", "836EABEDB4D2CD9BE6A4D957CF5EE6BF489304136864C55C2C5F01DA5047D18B", "199A0AB735E9004163DD02D319A61CFE81638E3BF47BB1E90E90D6E3EA545247"},
+	{"Path/ML-DSA-44/3", "CA5A01E1EA6552CB5C9803462B94C2F1DC9D13BB17A6ACE510D157056A2C6114", "8C8CACA88FFF52B9330510537B3701B3993F3726136A650F48F8604551550832"},
+	{"Path/ML-DSA-44/4", "9C005F1550B4F31855C6B92F978736733F37791CB39DD182D7BA5732BDC2483E", "B744343F30F7FEE088998BA574E799F1BF3939C06C29BF9AC10F3588A57E21E2"},
+	{"Path/ML-DSA-44/5", "4FAB5485B009399E8AE6FC3D3EEFBFE8E09796E4477AABD5EB1CC908FA734DE3", "7CAB0FDCF4BEA5F039137478AA45C9C48EF96D906FC49F6E2F138111BF1B4A4E"},
+	{"Path/ML-DSA-65/1", "464756A985E5DF03739D95DD309C1ED9C5B04254CC294E7E7EB9B9365EE15117", "491101BBA044DE6E44A63796C33CDA051BB05A60725B87AF4BA9DB940C03AC09"},
+	{"Path/ML-DSA-65/2", "235A48DB4CA7916B884F424A8586EFD517E87C64AECEC0FCE9A3CC212BA1522E", "F8CE85CB2EC474FFBF5A3FFAE029CE6F4526B8D597655067F97F438B81071E9B"},
+	{"Path/ML-DSA-65/3", "E13131B705A760305FEFFEBFE99082E2691A444BBEFCC3EDF67D909886200207", "CD365512C7E61BBAA130800B37F3BB46AAF1BEEF3742EA8A9010A6DD4576ED0B"},
+	{"Path/ML-DSA-65/4", "0A4793E040A4BC0D0F37643D12C1EA1F10648724609936C76E0EC83E37209E92", "6D9C7A795E48D80A892CBF4D4558429787277E3806EB5D0BCE1640EEBBBF9AEC"},
+	{"Path/ML-DSA-65/5", "F865B889E5022D54BABC81CA67E7EB39F1AC42F92CF5295C3DA5C9667DB1B924", "047AFAADBE020ED2D766DA85317DEDE80BE550545F0B21E3F555A990F8004258"},
+	{"Path/ML-DSA-87/1", "0D58219132746BE077DFE821E9F8FD87857B28AB91D6A567E312A73E2636032C", "3AA49EF72D010AEC19383BA1E83EC2DD3DCC207A96FFCEB9FFA269E3E3D66400"},
+	{"Path/ML-DSA-87/2", "146C47AB9F88408EB76A813294D533B29D7E0FDA75DA5A4E7C69EB61EFEEBB78", "82C44F998A8D24F056084D0E80ECFD8434493385A284C69974923C270D397782"},
+	{"Path/ML-DSA-87/3", "049D9B0B646A2AC7F50B63CE5E4BFE44C9B87634F4FF6C14C513E388B8A1F808", "FEBC9F8AE159002BE1A11D395959DD7FC20718135690CDAA2BCFB5801C02AB89"},
+	{"Path/ML-DSA-87/4", "9823DDDE446A8EA883DAD3AC6477F79839FDC2D2DEF2416BE0A8B71CFBC3F5C6", "F7592C97C1A96A2F4053588F5CDAD4C50BF7C3752709854FA27779B445DD2BA2"},
+	{"Path/ML-DSA-87/5", "AE213FE8589B414F53780D8B9B6837179967E13CB474C5AD365C043778D2BC90", "19C1913BA76FF04596BB7CC80FD825A5AEDEF5D5AD61CEDB5203E6D7EDB18877"},
+	{"Count/ML-DSA-44/77", "090D97C1F4166EB32CA67C5FB564ACBE0735DB4AF4B8DB3A7C2CE7402357CA44", "E3838364B37F47EDFCA2B577B20B80C3CB51B9F56E0E4CDB7DF002C874039252"},
+	{"Count/ML-DSA-44/100", "CFC73D07A883543A804F770070861825143A62F2F97D05FCE00FD8B25D29A43F", "0960C13E9BA467A938450120CC96FF6F04B7E557C99A838619A48F9A38738AB8"},
+	{"Count/ML-DSA-65/64a", "26B605C78AC762FA1634C6F91DD117C4FBFF7F3A7E7781F0CC83B6281F04AD7F", "C9B07E7DDC0274468F312F5C692A54AC73D1E34D8638E20A2CD3C788F27D4355"},
+	{"Count/ML-DSA-65/73", "9191CF381BEE17475C011986EFB6AFB1EFA6997442FD33427353F1DA1AA39FC0", "E616E36E81AA1EC39262109421AE0DDDA5E3B5A8F4A252BCA27AE882538DF618"},
+	{"Count/ML-DSA-65/66", "516912C7B90A3DBE009B7478DBCAF0F5C5C9ED9699A20D0CA56CC516E5A444CD", "9247CA75F9456226A0C783DABCC33FF5B4B489575ADED543E74B29B45F9C8EF2"},
+	{"Count/ML-DSA-65/65", "D4B841F882D50AB9E590066BAFABA0F0D04D32641C0B978E54CCAA69A6E8D2C4", "175231657B0F3C7065947999467C342064F29BFAEB553E97561407D5560E3AEB"},
+	{"Count/ML-DSA-65/64b", "5492EB8D811072C030A30CC66B23A173059EBA0D4868CCB92FBE2510B4A5915F", "33D2753ED87D0003B44C1AF5F72EB931F559C6B4931AF7E249F65D3FA7613295"},
+	{"Count/ML-DSA-87/64a", "B5C07ECEFE9E7C3B885FDEF032BDF9F807B4011E2DFE6806C088D2081631C8EB", "D1D5C2D167D6E62906790A5FEDF5A0A754CFAF47E6A11AEB93FB8C41934C31F8"},
+	{"Count/ML-DSA-87/65", "E8FC3C9FAD711DDA2946334FBBD331468D6E9AB48EB86DCD03F300A17AEBC5E5", "3B435F7A2CE431C7AB8EAE0991C5DAC610827C99D27803046FBC6C567D6B71F2"},
+	{"Count/ML-DSA-87/64b", "151F80886D6CE8C3B428964FE02C40CA0C8EFFA100EE089E54D785344FCCF719", "C628CE94D2AA99AA50CF15B147D4F9A9C62A3D4612152DE0A502C377F472D614"},
+	{"Count/ML-DSA-87/64c", "48BEFFB4C97E59E474E1906F39888BE5AE62F6A011C05EF6A6B8D1E54F2171B7", "D2756A8FB4E47F796AF704ED0FC8C6E573D42DFAB443B329F00F8DB2FF12C465"},
+	{"Count/ML-DSA-87/69", "FE2DA9DD93A077FCB6452AC88D0A5762EB896BAAAC6CE7D01CB1370BA8322390", "A86B29ADF2300D2636E21D4A350CD18E55A254379C3659A7A95D8734CEC1F005"},
+}
+
+var mldsaExternalMuTestCases = []mldsaExternalMuTestCase{
+	// From crypto/internal/fips140/mldsa/mldsa_test.go BenchmarkCAST.
+	{"CAST/ML-DSA-44", cng.MLDSA44(), "5C624FCC1862452452D0C665840D8237F43108E5499EDCDC108FBC49D596E4B7", "2ad1c72bb0fcbe28099ce8bd2ed836dfebe520aad38fbac66ef785a3cfb10fb419327fa57818ee4e3718da4be48d24b59a208f8807271fdb7eda6e60141bd263"},
+	{"CAST/ML-DSA-65", cng.MLDSA65(), "F215BA2280D86F142012FC05FFC04F2C7D22FF5DD7D69AA0EFB081E3A53E9318", "35cdb7dddbed44af4641bac659f46598ed769ea9693fd4ed2152b84c45811d2e66eded1eb20cde1c1f4b82642a330d8e86ac432a2aefaa56cd9b2b5f4affd450"},
+}
+
+func TestMLDSARoundTrip(t *testing.T) {
+	if !cng.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaParameterTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMLDSARoundTrip(t, test.params)
+		})
+	}
+}
+
+func testMLDSARoundTrip(t *testing.T, params cng.MLDSAParameters) {
+	t.Parallel()
+
+	generated1, err := cng.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated2, err := cng.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(generated1.Bytes(), generated2.Bytes()) {
+		t.Error("two generated private keys are equal")
+	}
+	if bytes.Equal(generated1.PublicKey().Bytes(), generated2.PublicKey().Bytes()) {
+		t.Error("two generated public keys are equal")
+	}
+
+	for _, testCase := range mldsaACVPTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			seed := fromHexBytes(testCase.seed)
+			privateKey, err := cng.NewPrivateKeyMLDSA(params, seed)
+			if err != nil {
+				t.Fatalf("NewPrivateKey: %v", err)
+			}
+			if !bytes.Equal(privateKey.Bytes(), seed) {
+				t.Error("private key seed changed")
+			}
+
+			publicKey := privateKey.PublicKey()
+			publicKeyBytes := publicKey.Bytes()
+			if len(publicKeyBytes) != params.PublicKeySize() {
+				t.Fatalf("public key length = %d, want %d", len(publicKeyBytes), params.PublicKeySize())
+			}
+			reparsedPublicKey, err := cng.NewPublicKeyMLDSA(params, publicKeyBytes)
+			if err != nil {
+				t.Fatalf("NewPublicKey: %v", err)
+			}
+			if !bytes.Equal(reparsedPublicKey.Bytes(), publicKeyBytes) {
+				t.Error("reparsed public key changed")
+			}
+
+			message := fromHexBytes(testCase.msg)
+			signature, err := privateKey.Sign(message, "")
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+			if len(signature) != params.SignatureSize() {
+				t.Fatalf("signature length = %d, want %d", len(signature), params.SignatureSize())
+			}
+			if err := reparsedPublicKey.Verify(message, signature, ""); err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			wrongMessage := append([]byte(nil), message...)
+			wrongMessage[0] ^= 0x80
+			if err := reparsedPublicKey.Verify(wrongMessage, signature, ""); err == nil {
+				t.Error("Verify passed on wrong message")
+			}
+
+			contextSignature, err := privateKey.Sign(message, "context")
+			if err != nil {
+				t.Fatalf("Sign with context: %v", err)
+			}
+			if err := reparsedPublicKey.Verify(message, contextSignature, "context"); err != nil {
+				t.Fatalf("Verify with context: %v", err)
+			}
+			if err := reparsedPublicKey.Verify(message, contextSignature, "wrong context"); err == nil {
+				t.Error("Verify passed with wrong context")
+			}
+
+			mu := append(fromHexBytes(testCase.msg), fromHexBytes(testCase.msg)...)
+			externalSignature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				t.Fatalf("SignExternalMu: %v", err)
+			}
+			if len(externalSignature) != params.SignatureSize() {
+				t.Fatalf("external signature length = %d, want %d", len(externalSignature), params.SignatureSize())
+			}
+			if err := reparsedPublicKey.VerifyExternalMu(mu, externalSignature); err != nil {
+				t.Fatalf("VerifyExternalMu: %v", err)
+			}
+			wrongMu := append([]byte(nil), mu...)
+			wrongMu[0] ^= 0x80
+			if err := reparsedPublicKey.VerifyExternalMu(wrongMu, externalSignature); err == nil {
+				t.Error("VerifyExternalMu passed on wrong message")
+			}
+		})
+	}
+}
+
+func TestMLDSABadLengths(t *testing.T) {
+	if !cng.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaParameterTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMLDSABadLengths(t, test.params)
+		})
+	}
+}
+
+func TestMLDSAExternalMuCASTVectors(t *testing.T) {
+	if !cng.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaExternalMuTestCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, err := cng.NewPrivateKeyMLDSA(test.params, fromHexBytes(test.seed))
+			if err != nil {
+				t.Fatalf("NewPrivateKey: %v", err)
+			}
+			publicKey := privateKey.PublicKey()
+			mu := fromHexBytes(test.mu)
+
+			signature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				t.Fatalf("SignExternalMu: %v", err)
+			}
+			if len(signature) != test.params.SignatureSize() {
+				t.Fatalf("signature length = %d, want %d", len(signature), test.params.SignatureSize())
+			}
+			if err := publicKey.VerifyExternalMu(mu, signature); err != nil {
+				t.Fatalf("VerifyExternalMu: %v", err)
+			}
+			wrongMu := append([]byte(nil), mu...)
+			wrongMu[0] ^= 0x80
+			if err := publicKey.VerifyExternalMu(wrongMu, signature); err == nil {
+				t.Error("VerifyExternalMu passed on wrong message")
+			}
+		})
+	}
+}
+
+func testMLDSABadLengths(t *testing.T, params cng.MLDSAParameters) {
+	t.Parallel()
+	privateKey, err := cng.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKeyBytes := privateKey.Bytes()
+	publicKeyBytes := privateKey.PublicKey().Bytes()
+	publicKey, err := cng.NewPublicKeyMLDSA(params, publicKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := []byte("message")
+	signature, err := privateKey.Sign(message, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cng.NewPrivateKeyMLDSA(params, privateKeyBytes[:len(privateKeyBytes)-1]); err == nil {
+		t.Error("NewPrivateKey accepted a short seed")
+	}
+	if _, err := cng.NewPrivateKeyMLDSA(params, append(privateKeyBytes, 0)); err == nil {
+		t.Error("NewPrivateKey accepted a long seed")
+	}
+	if _, err := cng.NewPublicKeyMLDSA(params, publicKeyBytes[:len(publicKeyBytes)-1]); err == nil {
+		t.Error("NewPublicKey accepted a short encoding")
+	}
+	if _, err := cng.NewPublicKeyMLDSA(params, append(publicKeyBytes, 0)); err == nil {
+		t.Error("NewPublicKey accepted a long encoding")
+	}
+	if err := publicKey.Verify(message, signature[:params.SignatureSize()-1], ""); err == nil {
+		t.Error("Verify accepted a short signature")
+	}
+	if err := publicKey.Verify(message, append(signature, 0), ""); err == nil {
+		t.Error("Verify accepted a long signature")
+	}
+	if _, err := privateKey.Sign(message, string(make([]byte, 256))); err == nil {
+		t.Error("Sign accepted a long context")
+	}
+	if _, err := privateKey.SignExternalMu(make([]byte, 63)); err == nil {
+		t.Error("SignExternalMu accepted a short mu")
+	}
+	if err := publicKey.VerifyExternalMu(make([]byte, 63), signature); err == nil {
+		t.Error("VerifyExternalMu accepted a short mu")
+	}
+}
+
+func BenchmarkMLDSAKeyGen(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				privateKey, err := cng.GenerateKeyMLDSA(test.params)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= privateKey.Bytes()[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAPublicKey(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				publicKey := privateKey.PublicKey()
+				sink ^= publicKey.Bytes()[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSASign(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			message := []byte("testing")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				signature, err := privateKey.Sign(message, "")
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= signature[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSASignExternalMu(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			mu := make([]byte, 64)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				signature, err := privateKey.SignExternalMu(mu)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= signature[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAVerify(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			publicKey := privateKey.PublicKey()
+			message := []byte("testing")
+			signature, err := privateKey.Sign(message, "")
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := publicKey.Verify(message, signature, ""); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAVerifyExternalMu(b *testing.B) {
+	if !cng.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			publicKey := privateKey.PublicKey()
+			mu := make([]byte, 64)
+			signature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := publicKey.VerifyExternalMu(mu, signature); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func newBenchmarkMLDSAPrivateKey(b *testing.B, params cng.MLDSAParameters) *cng.PrivateKeyMLDSA {
+	b.Helper()
+	seed := make([]byte, 32)
+	privateKey, err := cng.NewPrivateKeyMLDSA(params, seed)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return privateKey
+}
+
+func fromHexBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -38,6 +38,7 @@ const (
 	TLS1_1_KDF_ALGORITHM = "TLS1_1_KDF"
 	TLS1_2_KDF_ALGORITHM = "TLS1_2_KDF"
 	DSA_ALGORITHM        = "DSA"
+	MLDSA_ALGORITHM      = "ML-DSA"
 	MLKEM_ALGORITHM      = "ML-KEM"
 
 	CHACHA20_POLY1305_ALGORITHM = "CHACHA20_POLY1305"
@@ -74,6 +75,9 @@ const (
 	ECCPRIVATE_BLOB         = "ECCPRIVATEBLOB"
 	DSA_PUBLIC_BLOB         = "DSAPUBLICBLOB"
 	DSA_PRIVATE_BLOB        = "DSAPRIVATEBLOB"
+	PQDSA_PUBLIC_BLOB       = "PQDSAPUBLICBLOB"
+	PQDSA_PRIVATE_BLOB      = "PQDSAPRIVATEBLOB"
+	PQDSA_PRIVATE_SEED_BLOB = "PQDSAPRIVATESEEDBLOB"
 	MLKEM_PUBLIC_BLOB       = "MLKEMPUBLICBLOB"
 	MLKEM_PRIVATE_SEED_BLOB = "MLKEMPRIVATESEEDBLOB"
 )
@@ -136,8 +140,11 @@ const (
 )
 
 const (
-	// ML-KEM related properties and constants
+	// Post-quantum related properties and constants
 	PARAMETER_SET_NAME       = "ParameterSetName"
+	MLDSA_PARAMETER_SET_44   = "44"
+	MLDSA_PARAMETER_SET_65   = "65"
+	MLDSA_PARAMETER_SET_87   = "87"
 	MLKEM_PARAMETER_SET_768  = "768"
 	MLKEM_PARAMETER_SET_1024 = "1024"
 )
@@ -180,11 +187,13 @@ type DSA_PARAMETER_HEADER_V2 struct {
 type PadMode uint32
 
 const (
-	PAD_UNDEFINED PadMode = 0x0
-	PAD_NONE      PadMode = 0x1
-	PAD_PKCS1     PadMode = 0x2
-	PAD_OAEP      PadMode = 0x4
-	PAD_PSS       PadMode = 0x8
+	PAD_UNDEFINED     PadMode = 0x0
+	PAD_NONE          PadMode = 0x1
+	PAD_PKCS1         PadMode = 0x2
+	PAD_OAEP          PadMode = 0x4
+	PAD_PSS           PadMode = 0x8
+	PAD_PQDSA         PadMode = 0x20
+	MLDSA_EXTERNAL_MU PadMode = 0x40
 )
 
 type AlgorithmProviderFlags uint32
@@ -213,6 +222,10 @@ const (
 	DSA_PARAMETERS_MAGIC_V2 KeyBlobMagicNumber = 0x324d5044
 	DSA_PUBLIC_MAGIC_V2     KeyBlobMagicNumber = 0x32425044
 	DSA_PRIVATE_MAGIC_V2    KeyBlobMagicNumber = 0x32565044
+
+	MLDSA_PUBLIC_MAGIC       KeyBlobMagicNumber = 0x4B505344
+	MLDSA_PRIVATE_MAGIC      KeyBlobMagicNumber = 0x4B535344
+	MLDSA_PRIVATE_SEED_MAGIC KeyBlobMagicNumber = 0x53535344
 
 	MLKEM_PUBLIC_MAGIC       KeyBlobMagicNumber = 0x504B4C4D
 	MLKEM_PRIVATE_MAGIC      KeyBlobMagicNumber = 0x524B4C4D
@@ -285,6 +298,13 @@ type PKCS1_PADDING_INFO struct {
 type PSS_PADDING_INFO struct {
 	AlgId *uint16
 	Salt  uint32
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptsignhash
+type PQDSA_PADDING_INFO struct {
+	Context      *byte
+	ContextSize  uint32
+	PrehashAlgID *uint16
 }
 
 // https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob


### PR DESCRIPTION
## Summary
- add Windows CNG-backed ML-DSA key generation, import/export, signing, verification, and external-mu support
- add PQDSA/ML-DSA bcrypt constants and padding info
- add ML-DSA tests and benchmarks covering ML-DSA-44, ML-DSA-65, and ML-DSA-87, including external-mu CAST vectors

## Validation
- `go test .\cng -run TestMLDSA`
- `go test .\...`
- `go test .\cng -run '^$' -bench BenchmarkMLDSA -count=7`

## Benchmark Results

Median result from `go test .\cng -run '^$' -bench BenchmarkMLDSA -count=7`:

```text
FIPS enabled: false
goos: windows
goarch: arm64
pkg: github.com/microsoft/go-crypto-winnative/cng
BenchmarkMLDSAKeyGen/44-12                   2559            486918 ns/op             80 B/op           1 allocs/op
BenchmarkMLDSAKeyGen/65-12                   1608            767208 ns/op             80 B/op           1 allocs/op
BenchmarkMLDSAKeyGen/87-12                   1231            988277 ns/op             80 B/op           1 allocs/op
BenchmarkMLDSAPublicKey/44-12                7180            143429 ns/op           2688 B/op           1 allocs/op
BenchmarkMLDSAPublicKey/65-12                4135            251391 ns/op           2688 B/op           1 allocs/op
BenchmarkMLDSAPublicKey/87-12                3082            394252 ns/op           2688 B/op           1 allocs/op
BenchmarkMLDSASign/44-12                     2568            471373 ns/op           2688 B/op           1 allocs/op
BenchmarkMLDSASign/65-12                     1394            765736 ns/op           3456 B/op           1 allocs/op
BenchmarkMLDSASign/87-12                     1358            954466 ns/op           4864 B/op           1 allocs/op
BenchmarkMLDSASignExternalMu/44-12           2361            455997 ns/op           2688 B/op           1 allocs/op
BenchmarkMLDSASignExternalMu/65-12           1431            781286 ns/op           3456 B/op           1 allocs/op
BenchmarkMLDSASignExternalMu/87-12           1311            939654 ns/op           4864 B/op           1 allocs/op
BenchmarkMLDSAVerify/44-12                   9709            131244 ns/op              0 B/op           0 allocs/op
BenchmarkMLDSAVerify/65-12                   5188            226438 ns/op              0 B/op           0 allocs/op
BenchmarkMLDSAVerify/87-12                   2007            499192 ns/op              0 B/op           0 allocs/op
BenchmarkMLDSAVerifyExternalMu/44-12         7483            159488 ns/op              0 B/op           0 allocs/op
BenchmarkMLDSAVerifyExternalMu/65-12         4342            253182 ns/op              0 B/op           0 allocs/op
BenchmarkMLDSAVerifyExternalMu/87-12         2610            459891 ns/op              0 B/op           0 allocs/op
```