### PR TITLE
cng: return concrete Hash from hash constructors

### DIFF
--- a/cng/hash.go
+++ b/cng/hash.go
@@ -20,8 +20,6 @@ import (
 // maxHashSize is the size of SHA512 and SHA3_512, the largest hashes we support.
 const maxHashSize = 64
 
-type HashCloner = hash.Cloner
-
 // SupportsHash returns true if a hash.Hash implementation is supported for h.
 func SupportsHash(h crypto.Hash) bool {
 	switch h {
@@ -91,32 +89,32 @@ func SHA512(p []byte) (sum [64]byte) {
 }
 
 // NewMD4 returns a new MD4 hash.
-func NewMD4() hash.Hash {
+func NewMD4() *Hash {
 	return newHash(bcrypt.MD4_ALGORITHM)
 }
 
 // NewMD5 returns a new MD5 hash.
-func NewMD5() hash.Hash {
+func NewMD5() *Hash {
 	return newHash(bcrypt.MD5_ALGORITHM)
 }
 
 // NewSHA1 returns a new SHA1 hash.
-func NewSHA1() hash.Hash {
+func NewSHA1() *Hash {
 	return newHash(bcrypt.SHA1_ALGORITHM)
 }
 
 // NewSHA256 returns a new SHA256 hash.
-func NewSHA256() hash.Hash {
+func NewSHA256() *Hash {
 	return newHash(bcrypt.SHA256_ALGORITHM)
 }
 
 // NewSHA384 returns a new SHA384 hash.
-func NewSHA384() hash.Hash {
+func NewSHA384() *Hash {
 	return newHash(bcrypt.SHA384_ALGORITHM)
 }
 
 // NewSHA512 returns a new SHA512 hash.
-func NewSHA512() hash.Hash {
+func NewSHA512() *Hash {
 	return newHash(bcrypt.SHA512_ALGORITHM)
 }
 
@@ -160,7 +158,7 @@ func hashToID(h hash.Hash) string {
 }
 
 var _ hash.Hash = (*Hash)(nil)
-var _ HashCloner = (*Hash)(nil)
+var _ hash.Cloner = (*Hash)(nil)
 
 // FIPSApprovedHash reports whether this hash algorithm is FIPS 140-3 approved.
 func FIPSApprovedHash(h hash.Hash) bool {
@@ -189,7 +187,7 @@ func newHash(id string) *Hash {
 	// Don't call bcrypt.CreateHash yet, it would be wasteful
 	// if the caller only wants to know the hash type. This
 	// is a common pattern in this package, as some functions
-	// accept a `func() hash.Hash` parameter and call it just
+	// accept a hash constructor parameter and call it just
 	// to know the hash type.
 	return &Hash{alg: mustLoadHash(id, bcrypt.ALG_NONE_FLAG)}
 }
@@ -210,7 +208,7 @@ func (h *Hash) init() {
 	runtime.SetFinalizer(h, (*Hash).finalize)
 }
 
-func (h *Hash) Clone() (HashCloner, error) {
+func (h *Hash) Clone() (hash.Cloner, error) {
 	defer runtime.KeepAlive(h)
 	h2 := &Hash{alg: h.alg, key: bytes.Clone(h.key)}
 	if h.ctx != 0 {

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -10,14 +10,13 @@ import (
 	"bytes"
 	"crypto"
 	"hash"
-	"io"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
 	"github.com/microsoft/go-crypto-winnative/internal/cryptotest"
 )
 
-func cryptoToHash(h crypto.Hash) func() hash.Hash {
+func cryptoToHash(h crypto.Hash) func() *cng.Hash {
 	switch h {
 	case crypto.MD4:
 		return cng.NewMD4
@@ -32,11 +31,11 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 	case crypto.SHA512:
 		return cng.NewSHA512
 	case crypto.SHA3_256:
-		return func() hash.Hash { return cng.NewSHA3_256() }
+		return cng.NewSHA3_256
 	case crypto.SHA3_384:
-		return func() hash.Hash { return cng.NewSHA3_384() }
+		return cng.NewSHA3_384
 	case crypto.SHA3_512:
-		return func() hash.Hash { return cng.NewSHA3_512() }
+		return cng.NewSHA3_512
 	}
 	return nil
 }
@@ -79,9 +78,8 @@ func TestHash(t *testing.T) {
 				t.Error("Write didn't change internal hash state")
 			}
 
-			bw := h.(io.ByteWriter)
 			for i := 0; i < len(msg); i++ {
-				bw.WriteByte(msg[i])
+				h.WriteByte(msg[i])
 			}
 			h.Reset()
 			sum = h.Sum(nil)
@@ -89,7 +87,7 @@ func TestHash(t *testing.T) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}
 
-			h.(io.StringWriter).WriteString(string(msg))
+			h.WriteString(string(msg))
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
@@ -106,7 +104,7 @@ func TestHash_Clone(t *testing.T) {
 			if !cng.SupportsHash(tt) {
 				t.Skip("skipping: not supported")
 			}
-			h := cryptoToHash(tt)().(cng.HashCloner)
+			h := cryptoToHash(tt)()
 
 			_, err := h.Write(msg)
 			if err != nil {

--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -26,7 +26,7 @@ func loadHKDF() (bcrypt.ALG_HANDLE, error) {
 	})
 }
 
-func newHKDF(h func() hash.Hash, secret, salt []byte) (bcrypt.KEY_HANDLE, error) {
+func newHKDF[H hash.Hash](h func() H, secret, salt []byte) (bcrypt.KEY_HANDLE, error) {
 	ch := h()
 	hashID := hashToID(ch)
 	if hashID == "" {
@@ -58,7 +58,7 @@ func newHKDF(h func() hash.Hash, secret, salt []byte) (bcrypt.KEY_HANDLE, error)
 	return kh, nil
 }
 
-func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
+func ExtractHKDF[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	if salt == nil {
 		// Replicate x/crypto/hkdf behavior.
 		salt = make([]byte, h().Size())
@@ -92,7 +92,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 }
 
 // ExpandHKDF derives a key from the given hash, key, and optional context info.
-func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
+func ExpandHKDF[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
 	kh, err := newHKDF(h, pseudorandomKey, nil)
 	if err != nil {
 		return nil, err

--- a/cng/hkdf_test.go
+++ b/cng/hkdf_test.go
@@ -8,14 +8,13 @@ package cng_test
 
 import (
 	"bytes"
-	"hash"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
 )
 
 type hkdfTest struct {
-	hash   func() hash.Hash
+	hash   func() *cng.Hash
 	master []byte
 	salt   []byte
 	prk    []byte
@@ -294,7 +293,7 @@ var hkdfTests = []hkdfTest{
 	},
 }
 
-func newHKDF(hash func() hash.Hash, secret, salt, info []byte, keyLength int) ([]byte, error) {
+func newHKDF(hash func() *cng.Hash, secret, salt, info []byte, keyLength int) ([]byte, error) {
 	prk, err := cng.ExtractHKDF(hash, secret, salt)
 	if err != nil {
 		return nil, err

--- a/cng/hmac.go
+++ b/cng/hmac.go
@@ -14,11 +14,11 @@ import (
 )
 
 // NewHMAC returns a new HMAC using BCrypt.
-// The function h must return a hash implemented by
-// CNG (for example, h could be cng.NewSHA256).
-// If h is not recognized, NewHMAC returns nil.
-func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
-	ch := h()
+// The function fh must return a hash implemented by
+// CNG (for example, [NewSHA256]).
+// If fh is not recognized, NewHMAC returns nil.
+func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
+	ch := fh()
 	id := hashToID(ch)
 	if id == "" {
 		return nil
@@ -61,7 +61,7 @@ func (h hmacWrapper) BlockSize() int {
 	return h.hashX.BlockSize()
 }
 
-func (h hmacWrapper) Clone() (HashCloner, error) {
+func (h hmacWrapper) Clone() (hash.Cloner, error) {
 	clone, err := h.hashX.Clone()
 	if err != nil {
 		return nil, err

--- a/cng/hmac_test.go
+++ b/cng/hmac_test.go
@@ -9,7 +9,6 @@ package cng_test
 import (
 	"bytes"
 	"fmt"
-	"hash"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
@@ -19,7 +18,7 @@ func TestHMAC_EmptyKey(t *testing.T) {
 	const payload = "message"
 	var tests = []struct {
 		name string
-		fn   func() hash.Hash
+		fn   func() *cng.Hash
 		out  string
 	}{
 		{"sha1", cng.NewSHA1, "d5d1ed05121417247616cfc8378f360a39da7cfa"},
@@ -43,7 +42,7 @@ func TestHMAC(t *testing.T) {
 	key := []byte{1, 2, 3}
 	var tests = []struct {
 		name string
-		fn   func() hash.Hash
+		fn   func() *cng.Hash
 		key  []byte
 	}{
 		{"sha1", cng.NewSHA1, key},

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -20,8 +20,8 @@ func loadPBKDF2() (bcrypt.ALG_HANDLE, error) {
 	})
 }
 
-func PBKDF2(password, salt []byte, iter, keyLen int, h func() hash.Hash) ([]byte, error) {
-	ch := h()
+func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) ([]byte, error) {
+	ch := fh()
 	hashID := hashToID(ch)
 	if hashID == "" {
 		return nil, errors.New("cng: unsupported hash function")

--- a/cng/pbkdf2_test.go
+++ b/cng/pbkdf2_test.go
@@ -141,7 +141,7 @@ var sha256TestVectors = []testVector{
 	},
 }
 
-func testHash(t *testing.T, h func() hash.Hash, hashName string, vectors []testVector) {
+func testHash[H hash.Hash](t *testing.T, h func() H, hashName string, vectors []testVector) {
 	for i, v := range vectors {
 		o, err := cng.PBKDF2([]byte(v.password), []byte(v.salt), v.iter, len(v.output), h)
 		if err != nil {
@@ -179,7 +179,7 @@ func TestPBKDF2NoSalt(t *testing.T) {
 
 var sink uint8
 
-func benchmarkPBKDF2(b *testing.B, h func() hash.Hash) {
+func benchmarkPBKDF2[H hash.Hash](b *testing.B, h func() H) {
 	password := make([]byte, h().Size())
 	salt := make([]byte, 8)
 	var err error

--- a/cng/sha3_test.go
+++ b/cng/sha3_test.go
@@ -245,7 +245,7 @@ func benchmarkCSHAKE(b *testing.B, h *cng.SHAKE, size, num int) {
 	}
 }
 
-func benchHashSHA3(b *testing.B, h crypto.Hash, ctor func() hash.Hash, size, num int) {
+func benchHashSHA3[H hash.Hash](b *testing.B, h crypto.Hash, ctor func() H, size, num int) {
 	b.Helper()
 	if !cng.SupportsHash(h) {
 		b.Skipf("skipping: %v not supported", h)
@@ -262,15 +262,15 @@ func benchCSHAKE(b *testing.B, security int, ctor func() *cng.SHAKE, size, num i
 }
 
 func BenchmarkSHA3_512_MTU(b *testing.B) {
-	benchHashSHA3(b, crypto.SHA3_512, func() hash.Hash { return cng.NewSHA3_512() }, 1350, 1)
+	benchHashSHA3(b, crypto.SHA3_512, cng.NewSHA3_512, 1350, 1)
 }
 
 func BenchmarkSHA3_384_MTU(b *testing.B) {
-	benchHashSHA3(b, crypto.SHA3_384, func() hash.Hash { return cng.NewSHA3_384() }, 1350, 1)
+	benchHashSHA3(b, crypto.SHA3_384, cng.NewSHA3_384, 1350, 1)
 }
 
 func BenchmarkSHA3_256_MTU(b *testing.B) {
-	benchHashSHA3(b, crypto.SHA3_256, func() hash.Hash { return cng.NewSHA3_256() }, 1350, 1)
+	benchHashSHA3(b, crypto.SHA3_256, cng.NewSHA3_256, 1350, 1)
 }
 
 func BenchmarkCSHAKE128_MTU(b *testing.B)  { benchCSHAKE(b, 128, cng.NewSHAKE128, 1350, 1) }
@@ -279,5 +279,5 @@ func BenchmarkCSHAKE256_16x(b *testing.B)  { benchCSHAKE(b, 256, cng.NewSHAKE256
 func BenchmarkCSHAKE256_1MiB(b *testing.B) { benchCSHAKE(b, 256, cng.NewSHAKE256, 1024, 1024) }
 
 func BenchmarkCSHA3_512_1MiB(b *testing.B) {
-	benchHashSHA3(b, crypto.SHA3_512, func() hash.Hash { return cng.NewSHA3_512() }, 1024, 1024)
+	benchHashSHA3(b, crypto.SHA3_512, cng.NewSHA3_512, 1024, 1024)
 }

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -20,17 +20,19 @@ func loadTLS1PRF(id string) (bcrypt.ALG_HANDLE, error) {
 	})
 }
 
-// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil,
+// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if fh is nil,
 // else it implements the TLS 1.2 pseudo-random function.
+// To use TLS 1.0/1.1 mode with nil fh, specify the type parameter explicitly,
+// for example TLS1PRF[hash.Hash](result, secret, label, seed, nil).
 // The pseudo-random number will be written to result and will be of length len(result).
-func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
+func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error {
 	// TLS 1.0/1.1 PRF uses MD5SHA1.
 	algID := bcrypt.TLS1_1_KDF_ALGORITHM
 	var hashID string
-	if h != nil {
-		// If h is specified, assume the caller wants to use TLS 1.2 PRF.
+	if fh != nil {
+		// If fh is specified, assume the caller wants to use TLS 1.2 PRF.
 		// TLS 1.0/1.1 PRF doesn't allow specifying the hash function.
-		if hashID = hashToID(h()); hashID == "" {
+		if hashID = hashToID(fh()); hashID == "" {
 			return errors.New("cng: unsupported hash function")
 		}
 		algID = bcrypt.TLS1_2_KDF_ALGORITHM

--- a/cng/tls1prf_test.go
+++ b/cng/tls1prf_test.go
@@ -8,14 +8,13 @@ package cng_test
 
 import (
 	"bytes"
-	"hash"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
 )
 
 type tls1prfTest struct {
-	hash   func() hash.Hash
+	hash   func() *cng.Hash
 	secret []byte
 	label  []byte
 	seed   []byte
@@ -156,7 +155,7 @@ func TestTLS1PRF(t *testing.T) {
 		result := make([]byte, len(tt.out))
 		err := cng.TLS1PRF(result, tt.secret, tt.label, tt.seed, tt.hash)
 		if err != nil {
-			t.Errorf("test %d: error deriving TLS 1.2 PRF: %v.", i, err)
+			t.Errorf("test %d: error deriving TLS PRF: %v.", i, err)
 		}
 		if !bytes.Equal(result, tt.out) {
 			t.Errorf("test %d: incorrect key output: have %v, need %v.", i, result, tt.out)

--- a/internal/cryptotest/hash.go
+++ b/internal/cryptotest/hash.go
@@ -13,11 +13,11 @@ import (
 	"time"
 )
 
-type MakeHash func() hash.Hash
+type MakeHash[H hash.Hash] func() H
 
 // TestHash performs a set of tests on hash.Hash implementations, checking the
 // documented requirements of Write, Sum, Reset, Size, and BlockSize.
-func TestHash(t *testing.T, mh MakeHash) {
+func TestHash[H hash.Hash](t *testing.T, mh MakeHash[H]) {
 
 	// Test that Sum returns an appended digest matching output of Size
 	t.Run("SumAppend", func(t *testing.T) {


### PR DESCRIPTION
Ports microsoft/go-crypto-openssl#21 to CNG.

Summary:
- Return concrete *Hash values from hash constructors and remove the HashCloner alias.
- Make HMAC, HKDF, PBKDF2, and TLS1PRF accept generic hash constructors.
- Update hash-related tests and the shared cryptotest helper.

Tests:
- go test ./...