### PR TITLE
test: benchcheck variance-detection [do not merge]

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   benchmark:
-    uses: microsoft/go-infra/.github/workflows/benchmark.yml@eae52708dd530100eb695850bfc7f994dd9340d3 # v0.0.14
+    uses: microsoft/go-infra/.github/workflows/benchmark.yml@30600de4b8fb295da6b9f4ae77fe24b9b300c27a # test: benchcheck job-urls
     permissions:
       actions: read
       contents: read

--- a/TEST-benchcheck-variance.md
+++ b/TEST-benchcheck-variance.md
@@ -1,0 +1,7 @@
+# Test PR — do not merge
+
+Temporary trigger for a benchmark workflow run that pins
+`microsoft/go-infra` to a `benchcheck` branch under review
+(job-urls subcommand, on top of the merged variance + test2json work).
+
+Delete this file and close the PR once the run has been reviewed.


### PR DESCRIPTION
**Do not merge — throwaway test PR.**

Pins `microsoft/go-infra` in the reusable benchmark workflow to commit `187c2fa` so `benchcheck` is built from the branch under review, which adds:
- variance-aware regression detection (compare confidence-interval bounds instead of medians),
- per-sample variance (`±spread`) in the report,
- failing `benchcheck report` on genuine result-file read errors.

Benchmarks are unchanged here, so the expected outcome is a **'no significant regressions'** comment — this validates that `benchcheck` builds and runs from the pinned commit end-to-end. The `TEST-benchcheck-variance.md` marker exists only to trigger the `paths-ignore: .github/**` workflow.

Close this PR (and delete the marker) once the run is reviewed.