### PR TITLE
cng: add support for windows/386

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,25 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25, 1.26]
-        venv: [windows-2022, windows-2025, windows-11-arm]
+        target:
+          - venv: windows-2022
+            goarch: amd64
+          - venv: windows-2025
+            goarch: amd64
+          - venv: windows-11-arm
+            goarch: arm64
+          - venv: windows-2022
+            goarch: '386'
         fips: [1, 0]
-    runs-on: ${{ matrix.venv }}
+    runs-on: ${{ matrix.target.venv }}
+    env:
+      GOARCH: ${{ matrix.target.goarch }}
     steps:
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
         # There's not a Mirosoft build of Go 1.25 for Windows 11 ARM, so use the stdlib instead.
-        go-download-base-url: ${{ (matrix.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
+        go-download-base-url: ${{ (matrix.target.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set FIPS mode

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
-        # There's not a Mirosoft build of Go 1.25 for Windows 11 ARM, so use the stdlib instead.
+        # There's not a Microsoft build of Go 1.25 for Windows 11 ARM, so use the stdlib instead.
         go-download-base-url: ${{ (matrix.target.venv != 'windows-11-arm' || matrix.go-version != 1.25) && 'https://aka.ms/golang/release/latest' || '' }}
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/cng/aes_test.go
+++ b/cng/aes_test.go
@@ -10,6 +10,8 @@ import (
 	"bytes"
 	"crypto/cipher"
 	"fmt"
+	"math"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -208,13 +210,11 @@ func TestSealPanic(t *testing.T) {
 	assertPanic(t, func() {
 		gcm.Seal(nil, make([]byte, gcmStandardNonceSize-1), []byte{0x01, 0x02, 0x03}, nil)
 	})
-	assertPanic(t, func() {
-		// maxInt is implemented as math.MaxInt, but this constant
-		// is only available since go1.17.
-		// TODO: use math.MaxInt once go1.16 is no longer supported.
-		maxInt := int((^uint(0)) >> 1)
-		gcm.Seal(nil, make([]byte, gcmStandardNonceSize), make([]byte, maxInt), nil)
-	})
+	if runtime.GOARCH != "386" {
+		assertPanic(t, func() {
+			gcm.Seal(nil, make([]byte, gcmStandardNonceSize), make([]byte, math.MaxInt), nil)
+		})
+	}
 }
 
 func TestAESInvalidKeySize(t *testing.T) {

--- a/cng/big.go
+++ b/cng/big.go
@@ -16,15 +16,13 @@ import "math/bits"
 // Conversion between BigInt and *big.Int is in cng/bbig.
 type BigInt []byte
 
-const _S = bits.UintSize / 8 // word size in bytes
-
 // Length of x in bits.
 func (x BigInt) bitLen() int {
 	if len(x) == 0 {
 		return 0
 	}
 	// x is normalized, so the length in bits is
-	// the length in bits of x minus one byte (_S),
+	// the length in bits of x minus one byte,
 	// plus the minimum number of bits to represent the first byte.
-	return (len(x)-1)*_S + bits.Len(uint(x[0]))
+	return (len(x)-1)*8 + bits.Len8(x[0])
 }

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -36,6 +36,9 @@ func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) (
 	}
 	defer bcrypt.DestroyKey(kh)
 	u16HashID := utf16FromString(hashID)
+	if iter <= 0 {
+		return nil, errors.New("cng: invalid iteration count")
+	}
 	iterations := uint64(iter)
 	buffers := make([]bcrypt.Buffer, 0, 3)
 	buffers = append(buffers,

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -36,11 +36,12 @@ func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) (
 	}
 	defer bcrypt.DestroyKey(kh)
 	u16HashID := utf16FromString(hashID)
+	iterations := uint64(iter)
 	buffers := make([]bcrypt.Buffer, 0, 3)
 	buffers = append(buffers,
 		bcrypt.Buffer{
 			Type:   bcrypt.KDF_ITERATION_COUNT,
-			Data:   uintptr(unsafe.Pointer(&iter)),
+			Data:   uintptr(unsafe.Pointer(&iterations)),
 			Length: 8,
 		},
 		bcrypt.Buffer{

--- a/cng/rand_test.go
+++ b/cng/rand_test.go
@@ -8,6 +8,7 @@ package cng_test
 
 import (
 	"io"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
@@ -29,7 +30,11 @@ func TestRandBig(t *testing.T) {
 		// This test can take ~20s to complete.
 		t.Skip("skipping test in short mode.")
 	}
-	b := make([]byte, 1<<32+60)
+	if runtime.GOARCH == "386" {
+		t.Skip("skipping test on windows/386")
+	}
+	size := uint64(1)<<32 + 60
+	b := make([]byte, int(size))
 	n, err := io.ReadFull(cng.RandReader, b)
 	if err != nil {
 		t.Fatal(err)

--- a/cng/sha3_test.go
+++ b/cng/sha3_test.go
@@ -13,6 +13,7 @@ import (
 	"hash"
 	"io"
 	"math/rand"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
@@ -156,6 +157,9 @@ func testCSHAKEAccumulated(t *testing.T, newCSHAKE func(N, S []byte) *cng.SHAKE,
 }
 
 func TestCSHAKELargeS(t *testing.T) {
+	if runtime.GOARCH == "386" {
+		t.Skip("skipping test on windows/386")
+	}
 	if !cng.SupportsSHAKE(128) {
 		t.Skip("skipping: not supported")
 	}

--- a/internal/bcrypt/authinfo_windows.go
+++ b/internal/bcrypt/authinfo_windows.go
@@ -1,0 +1,21 @@
+//go:build !386
+// +build !386
+
+package bcrypt
+
+// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
+type AUTHENTICATED_CIPHER_MODE_INFO struct {
+	Size           uint32
+	InfoVersion    uint32
+	Nonce          *byte
+	NonceSize      uint32
+	AuthData       *byte
+	AuthDataSize   uint32
+	Tag            *byte
+	TagSize        uint32
+	MacContext     *byte
+	MacContextSize uint32
+	AADSize        uint32
+	DataSize       uint64
+	Flags          uint32
+}

--- a/internal/bcrypt/authinfo_windows_386.go
+++ b/internal/bcrypt/authinfo_windows_386.go
@@ -1,0 +1,23 @@
+//go:build windows && 386
+// +build windows,386
+
+package bcrypt
+
+// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
+type AUTHENTICATED_CIPHER_MODE_INFO struct {
+	Size           uint32
+	InfoVersion    uint32
+	Nonce          *byte
+	NonceSize      uint32
+	AuthData       *byte
+	AuthDataSize   uint32
+	Tag            *byte
+	TagSize        uint32
+	MacContext     *byte
+	MacContextSize uint32
+	AADSize        uint32
+	_              uint32
+	DataSize       uint64
+	Flags          uint32
+	_              uint32
+}

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -247,23 +247,6 @@ type KEY_LENGTHS_STRUCT struct {
 	Increment uint32
 }
 
-// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
-type AUTHENTICATED_CIPHER_MODE_INFO struct {
-	Size           uint32
-	InfoVersion    uint32
-	Nonce          *byte
-	NonceSize      uint32
-	AuthData       *byte
-	AuthDataSize   uint32
-	Tag            *byte
-	TagSize        uint32
-	MacContext     *byte
-	MacContextSize uint32
-	AADSize        uint32
-	DataSize       uint64
-	Flags          uint32
-}
-
 func NewAUTHENTICATED_CIPHER_MODE_INFO(nonce, additionalData, tag []byte) *AUTHENTICATED_CIPHER_MODE_INFO {
 	var aad *byte
 	if len(additionalData) > 0 {


### PR DESCRIPTION
## Summary
- add the correct x86 layout for `BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO`
- fix architecture-dependent RSA bit lengths and the PBKDF2 iteration buffer width
- avoid oversized test allocations that cannot run in a 32-bit address space
- add windows/386 to the CI test matrix

## Testing
- `go test ./... -count=1 -timeout=10m`
- `GOOS=windows GOARCH=386 go test ./... -count=1 -timeout=10m`
- `GOOS=windows GOARCH=386 go test -gcflags=all=-d=checkptr -count=1 ./... -timeout=10m`