### PR TITLE
cng: keep KDF parameter buffers alive

### DIFF
--- a/cng/hkdf.go
+++ b/cng/hkdf.go
@@ -111,13 +111,13 @@ func ExpandHKDF[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLength
 			Buffers: &bcrypt.Buffer{
 				Length: uint32(len(info)),
 				Type:   bcrypt.KDF_HKDF_INFO,
-				Data:   uintptr(unsafe.Pointer(&info[0])),
+				Data:   unsafe.Pointer(&info[0]),
 			},
 		}
-		defer runtime.KeepAlive(params)
 	}
 	var n uint32
 	err = bcrypt.KeyDerivation(kh, params, out, &n, 0)
+	runtime.KeepAlive(params)
 	if err != nil {
 		return nil, err
 	}

--- a/cng/pbkdf2.go
+++ b/cng/pbkdf2.go
@@ -9,6 +9,7 @@ package cng
 import (
 	"errors"
 	"hash"
+	"runtime"
 	"unsafe"
 
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -44,19 +45,19 @@ func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) (
 	buffers = append(buffers,
 		bcrypt.Buffer{
 			Type:   bcrypt.KDF_ITERATION_COUNT,
-			Data:   uintptr(unsafe.Pointer(&iterations)),
+			Data:   unsafe.Pointer(&iterations),
 			Length: 8,
 		},
 		bcrypt.Buffer{
 			Type:   bcrypt.KDF_HASH_ALGORITHM,
-			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
+			Data:   unsafe.Pointer(&u16HashID[0]),
 			Length: uint32(len(u16HashID) * 2),
 		})
 	if len(salt) > 0 {
 		// The salt is optional.
 		buffers = append(buffers, bcrypt.Buffer{
 			Type:   bcrypt.KDF_SALT,
-			Data:   uintptr(unsafe.Pointer(&salt[0])),
+			Data:   unsafe.Pointer(&salt[0]),
 			Length: uint32(len(salt)),
 		})
 	}
@@ -67,6 +68,7 @@ func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) (
 	out := make([]byte, keyLen)
 	var size uint32
 	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
+	runtime.KeepAlive(params)
 	if err != nil {
 		return nil, err
 	}

--- a/cng/pbkdf2_test.go
+++ b/cng/pbkdf2_test.go
@@ -9,6 +9,7 @@ package cng_test
 import (
 	"bytes"
 	"hash"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/go-crypto-winnative/cng"
@@ -175,6 +176,62 @@ func TestPBKDF2NoSalt(t *testing.T) {
 		},
 	}
 	testHash(t, cng.NewSHA256, "SHA256", vectors)
+}
+
+type pbkdf2SaltOwner struct {
+	bytes [32]byte
+}
+
+func newPBKDF2SaltOwner() *pbkdf2SaltOwner {
+	owner := new(pbkdf2SaltOwner)
+	copy(owner.bytes[:], "pbkdf2-output-regression-salt")
+	return owner
+}
+
+func deriveWithCollectableSalt(owner *pbkdf2SaltOwner, keyLength int) ([]byte, error) {
+	salt := owner.bytes[:]
+	owner = nil
+	return cng.PBKDF2([]byte("password"), salt, 1, keyLength, cng.NewSHA256)
+}
+
+func TestPBKDF2KeepsSaltAlive(t *testing.T) {
+	const keyLength = 4 << 20
+	referenceOwner := newPBKDF2SaltOwner()
+	expected, err := cng.PBKDF2([]byte("password"), referenceOwner.bytes[:], 1, keyLength, cng.NewSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.KeepAlive(referenceOwner)
+
+	owner := newPBKDF2SaltOwner()
+	runtime.SetFinalizer(owner, func(owner *pbkdf2SaltOwner) {
+		for i := range owner.bytes {
+			owner.bytes[i] = 0xff
+		}
+	})
+
+	stopGC := make(chan struct{})
+	gcDone := make(chan struct{})
+	go func() {
+		defer close(gcDone)
+		for {
+			select {
+			case <-stopGC:
+				return
+			default:
+				runtime.GC()
+			}
+		}
+	}()
+	actual, err := deriveWithCollectableSalt(owner, keyLength)
+	close(stopGC)
+	<-gcDone
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(actual, expected) {
+		t.Fatal("PBKDF2 output changed when GC ran during derivation")
+	}
 }
 
 var sink uint8

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -9,6 +9,7 @@ package cng
 import (
 	"errors"
 	"hash"
+	"runtime"
 	"unsafe"
 
 	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -52,14 +53,14 @@ func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error
 	if len(label) > 0 {
 		buffers = append(buffers, bcrypt.Buffer{
 			Type:   bcrypt.KDF_TLS_PRF_LABEL,
-			Data:   uintptr(unsafe.Pointer(&label[0])),
+			Data:   unsafe.Pointer(&label[0]),
 			Length: uint32(len(label)),
 		})
 	}
 	if len(seed) > 0 {
 		buffers = append(buffers, bcrypt.Buffer{
 			Type:   bcrypt.KDF_TLS_PRF_SEED,
-			Data:   uintptr(unsafe.Pointer(&seed[0])),
+			Data:   unsafe.Pointer(&seed[0]),
 			Length: uint32(len(seed)),
 		})
 	}
@@ -67,7 +68,7 @@ func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error
 		u16HashID := utf16FromString(hashID)
 		buffers = append(buffers, bcrypt.Buffer{
 			Type:   bcrypt.KDF_HASH_ALGORITHM,
-			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
+			Data:   unsafe.Pointer(&u16HashID[0]),
 			Length: uint32(len(u16HashID) * 2),
 		})
 	}
@@ -77,6 +78,7 @@ func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error
 	}
 	var size uint32
 	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)
+	runtime.KeepAlive(params)
 	if err != nil {
 		return err
 	}

--- a/cng/tls1prf.go
+++ b/cng/tls1prf.go
@@ -73,8 +73,10 @@ func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error
 		})
 	}
 	params := &bcrypt.BufferDesc{
-		Count:   uint32(len(buffers)),
-		Buffers: &buffers[0],
+		Count: uint32(len(buffers)),
+	}
+	if len(buffers) > 0 {
+		params.Buffers = &buffers[0]
 	}
 	var size uint32
 	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)

--- a/internal/bcrypt/bcrypt_windows.go
+++ b/internal/bcrypt/bcrypt_windows.go
@@ -113,7 +113,7 @@ type KEY_DATA_BLOB_HEADER struct {
 type Buffer struct {
 	Length uint32
 	Type   uint32
-	Data   uintptr
+	Data   unsafe.Pointer
 }
 
 type BufferDesc struct {


### PR DESCRIPTION
## Summary
- keep BCrypt KDF parameter payloads visible to the Go garbage collector
- retain parameter descriptors until `BCryptKeyDerivation` returns for PBKDF2, HKDF, and TLS PRF
- add a public PBKDF2 regression test that forces GC and verifies the derived key bytes

## Impact
The previous `uintptr` fields did not keep their backing Go objects reachable. If the caller's last live reference disappeared while CNG was still deriving, a concurrent GC could make an input buffer available for finalization or reuse and the derivation could return incorrect bytes.

This should be unlikely in typical applications: KDF outputs are usually small, the native call window is short, and GC plus memory modification or reuse must occur during that window. It becomes more plausible with unusually large outputs or heavy GC/allocation pressure. The regression test makes the timing deterministic by using a large output and a finalizer that overwrites the salt.

## Testing
- `go test ./...`
- `go test -v ./cng -run '^TestPBKDF2KeepsSaltAlive$' -count=10 -timeout=90s`
- `go vet ./...`
