### PR TITLE
cng: use runtime.AddCleanup

### DIFF
--- a/cng/aes.go
+++ b/cng/aes.go
@@ -30,12 +30,8 @@ func NewAESCipher(key []byte) (cipher.Block, error) {
 		return nil, err
 	}
 	c := &aesCipher{kh: kh, key: bytes.Clone(key)}
-	runtime.SetFinalizer(c, (*aesCipher).finalize)
+	runtime.AddCleanup(c, destroyKey, c.kh)
 	return c, nil
-}
-
-func (c *aesCipher) finalize() {
-	bcrypt.DestroyKey(c.kh)
 }
 
 func (c *aesCipher) BlockSize() int { return aesBlockSize }
@@ -165,13 +161,9 @@ func newCBC(encrypt bool, alg string, key, iv []byte) *cbcCipher {
 		panic(err)
 	}
 	x := &cbcCipher{kh: kh, encrypt: encrypt, blockSize: blockSize}
-	runtime.SetFinalizer(x, (*cbcCipher).finalize)
+	runtime.AddCleanup(x, destroyKey, x.kh)
 	x.SetIV(iv)
 	return x
-}
-
-func (x *cbcCipher) finalize() {
-	bcrypt.DestroyKey(x.kh)
 }
 
 func (x *cbcCipher) BlockSize() int { return x.blockSize }
@@ -247,17 +239,13 @@ type aesGCM struct {
 	maskInitialized bool
 }
 
-func (g *aesGCM) finalize() {
-	bcrypt.DestroyKey(g.kh)
-}
-
 func newGCM(key []byte, tls cipherGCMTLS) (*aesGCM, error) {
 	kh, err := newCipherHandle(bcrypt.AES_ALGORITHM, bcrypt.CHAIN_MODE_GCM, key)
 	if err != nil {
 		return nil, err
 	}
 	g := &aesGCM{kh: kh, tls: tls}
-	runtime.SetFinalizer(g, (*aesGCM).finalize)
+	runtime.AddCleanup(g, destroyKey, g.kh)
 	return g, nil
 }
 

--- a/cng/chacha20poly1305.go
+++ b/cng/chacha20poly1305.go
@@ -40,14 +40,8 @@ func NewChaCha20Poly1305(key []byte) (cipher.AEAD, error) {
 		return nil, err
 	}
 	c := &chacha20poly1305{kh: kh}
-	runtime.SetFinalizer(c, (*chacha20poly1305).finalize)
+	runtime.AddCleanup(c, destroyKey, c.kh)
 	return c, nil
-}
-
-func (c *chacha20poly1305) finalize() {
-	if c.kh != nil {
-		bcrypt.DestroyKey(c.kh)
-	}
 }
 
 func (c *chacha20poly1305) NonceSize() int {

--- a/cng/des.go
+++ b/cng/des.go
@@ -29,7 +29,7 @@ func NewDESCipher(key []byte) (cipher.Block, error) {
 		return nil, err
 	}
 	c := &desCipher{kh: kh, alg: bcrypt.DES_ALGORITHM, key: bytes.Clone(key)}
-	runtime.SetFinalizer(c, (*desCipher).finalize)
+	runtime.AddCleanup(c, destroyKey, c.kh)
 	return c, nil
 }
 
@@ -39,12 +39,8 @@ func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 		return nil, err
 	}
 	c := &desCipher{kh: kh, alg: bcrypt.DES3_ALGORITHM, key: bytes.Clone(key)}
-	runtime.SetFinalizer(c, (*desCipher).finalize)
+	runtime.AddCleanup(c, destroyKey, c.kh)
 	return c, nil
-}
-
-func (c *desCipher) finalize() {
-	bcrypt.DestroyKey(c.kh)
 }
 
 func (c *desCipher) BlockSize() int { return desBlockSize }

--- a/cng/dsa.go
+++ b/cng/dsa.go
@@ -96,20 +96,12 @@ type PrivateKeyDSA struct {
 	hkey bcrypt.KEY_HANDLE
 }
 
-func (k *PrivateKeyDSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
-}
-
 // PublicKeyDSA represents a DSA public key.
 type PublicKeyDSA struct {
 	DSAParameters
 	Y BigInt
 
 	hkey bcrypt.KEY_HANDLE
-}
-
-func (k *PublicKeyDSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 // GenerateKeyDSA generates a new private DSA key using the given parameters.
@@ -155,7 +147,7 @@ func NewPrivateKeyDSA(params DSAParameters, X, Y BigInt) (*PrivateKeyDSA, error)
 		return nil, err
 	}
 	k := &PrivateKeyDSA{params, X, Y, hkey}
-	runtime.SetFinalizer(k, (*PrivateKeyDSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
 }
 
@@ -174,7 +166,7 @@ func NewPublicKeyDSA(params DSAParameters, Y BigInt) (*PublicKeyDSA, error) {
 		return nil, err
 	}
 	k := &PublicKeyDSA{params, Y, hkey}
-	runtime.SetFinalizer(k, (*PublicKeyDSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
 }
 

--- a/cng/ecdh.go
+++ b/cng/ecdh.go
@@ -52,25 +52,15 @@ type PublicKeyECDH struct {
 	bytes []byte
 
 	// priv is only set when PublicKeyECDH is derived from a private key,
-	// in which case priv's finalizer is responsible for freeing hkey.
-	// This ensures priv is not finalized while the public key is alive,
+	// in which case priv's cleanup is responsible for freeing hkey.
+	// This ensures priv is not cleaned up while the public key is alive,
 	// which could cause use-after-free and double-free behavior.
 	priv *PrivateKeyECDH
-}
-
-func (k *PublicKeyECDH) finalize() {
-	if k.priv == nil {
-		bcrypt.DestroyKey(k.hkey)
-	}
 }
 
 type PrivateKeyECDH struct {
 	hkey   bcrypt.KEY_HANDLE
 	isNIST bool
-}
-
-func (k *PrivateKeyECDH) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
@@ -138,7 +128,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	bytes = bytes[hdr.CbKey*2:]
 
 	k := &PrivateKeyECDH{hkey, isNIST(curve)}
-	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, bytes, nil
 }
 
@@ -173,7 +163,7 @@ func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 		return nil, err
 	}
 	k := &PublicKeyECDH{hkey, append([]byte(nil), bytes...), nil}
-	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
 }
 
@@ -202,7 +192,7 @@ func NewPrivateKeyECDH(curve string, key []byte) (*PrivateKeyECDH, error) {
 		return nil, err
 	}
 	k := &PrivateKeyECDH{hkey, nist}
-	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
 }
 
@@ -221,7 +211,6 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 		bytes = data[:hdr.CbKey]
 	}
 	pub := &PublicKeyECDH{k.hkey, bytes, k}
-	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 	return pub, nil
 }
 

--- a/cng/ecdsa.go
+++ b/cng/ecdsa.go
@@ -90,12 +90,8 @@ func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
 		return nil, err
 	}
 	k := &PublicKeyECDSA{hkey}
-	runtime.SetFinalizer(k, (*PublicKeyECDSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
-}
-
-func (k *PublicKeyECDSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 type PrivateKeyECDSA struct {
@@ -112,12 +108,8 @@ func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error) 
 		return nil, err
 	}
 	k := &PrivateKeyECDSA{hkey}
-	runtime.SetFinalizer(k, (*PrivateKeyECDSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
-}
-
-func (k *PrivateKeyECDSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 // SignECDSA signs a hash (which should be the result of hashing a larger message),

--- a/cng/hash.go
+++ b/cng/hash.go
@@ -192,8 +192,8 @@ func newHash(id string) *Hash {
 	return &Hash{alg: mustLoadHash(id, bcrypt.ALG_NONE_FLAG)}
 }
 
-func (h *Hash) finalize() {
-	bcrypt.DestroyHash(h.ctx)
+func destroyHash(ctx bcrypt.HASH_HANDLE) {
+	bcrypt.DestroyHash(ctx)
 }
 
 func (h *Hash) init() {
@@ -205,7 +205,7 @@ func (h *Hash) init() {
 	if err != nil {
 		panic(err)
 	}
-	runtime.SetFinalizer(h, (*Hash).finalize)
+	runtime.AddCleanup(h, destroyHash, h.ctx)
 }
 
 func (h *Hash) Clone() (hash.Cloner, error) {
@@ -213,7 +213,7 @@ func (h *Hash) Clone() (hash.Cloner, error) {
 	h2 := &Hash{alg: h.alg, key: bytes.Clone(h.key)}
 	if h.ctx != nil {
 		hashClone(h.ctx, &h2.ctx)
-		runtime.SetFinalizer(h2, (*Hash).finalize)
+		runtime.AddCleanup(h2, destroyHash, h2.ctx)
 	}
 	return h2, nil
 }

--- a/cng/hash_test.go
+++ b/cng/hash_test.go
@@ -266,7 +266,7 @@ func TestHashStructAllocations(t *testing.T) {
 		sha512Hash.Reset()
 	}))
 	// Each hash allocates 3 times: once for the hash struct, and twice
-	// for the SetFinalizer call (argument and func).
+	// for the AddCleanup call (argument and func).
 	want := 18
 	if n > want {
 		t.Errorf("allocs = %d, want %d", n, want)

--- a/cng/keys.go
+++ b/cng/keys.go
@@ -23,6 +23,12 @@ const (
 	sizeOfDSAParamsV2Header = uint32(unsafe.Sizeof(bcrypt.DSA_PARAMETER_HEADER_V2{}))
 )
 
+func destroyKey(hkey bcrypt.KEY_HANDLE) {
+	if hkey != nil {
+		bcrypt.DestroyKey(hkey)
+	}
+}
+
 // exportDSAKey exports hkey into a bcrypt.DSA_KEY_BLOB header and data.
 func exportDSAKey(hkey bcrypt.KEY_HANDLE, private bool) (bcrypt.DSA_KEY_BLOB, []byte, error) {
 	var magic string

--- a/cng/rc4.go
+++ b/cng/rc4.go
@@ -15,7 +15,8 @@ import (
 
 // A RC4Cipher is an instance of RC4 using a particular key.
 type RC4Cipher struct {
-	kh bcrypt.KEY_HANDLE
+	kh      bcrypt.KEY_HANDLE
+	cleanup runtime.Cleanup
 }
 
 // NewRC4Cipher creates and returns a new Cipher.
@@ -25,18 +26,17 @@ func NewRC4Cipher(key []byte) (*RC4Cipher, error) {
 		return nil, err
 	}
 	c := &RC4Cipher{kh: kh}
-	runtime.SetFinalizer(c, (*RC4Cipher).finalize)
+	c.cleanup = runtime.AddCleanup(c, destroyKey, c.kh)
 	return c, nil
-}
-
-func (c *RC4Cipher) finalize() {
-	if c.kh != nil {
-		bcrypt.DestroyKey(c.kh)
-	}
 }
 
 // Reset zeros the key data and makes the Cipher unusable.
 func (c *RC4Cipher) Reset() {
+	defer runtime.KeepAlive(c)
+	if c.kh == nil {
+		return
+	}
+	c.cleanup.Stop()
 	bcrypt.DestroyKey(c.kh)
 	c.kh = nil
 }

--- a/cng/rc4_test.go
+++ b/cng/rc4_test.go
@@ -147,6 +147,21 @@ func TestRC4Stream(t *testing.T) {
 	})
 }
 
+func TestRC4Reset(t *testing.T) {
+	c, err := cng.NewRC4Cipher(golden[0].key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Reset()
+	c.Reset()
+
+	dst := []byte{0xff}
+	c.XORKeyStream(dst, []byte{0})
+	if dst[0] != 0xff {
+		t.Fatal("XORKeyStream modified dst after Reset")
+	}
+}
+
 func benchmarkRC4(b *testing.B, size int64) {
 	buf := make([]byte, size)
 	c, err := cng.NewRC4Cipher(golden[0].key)

--- a/cng/rsa.go
+++ b/cng/rsa.go
@@ -95,21 +95,13 @@ func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
 		return nil, err
 	}
 	k := &PublicKeyRSA{hkey, uint32(N.bitLen())}
-	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
-}
-
-func (k *PublicKeyRSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 type PrivateKeyRSA struct {
 	hkey bcrypt.KEY_HANDLE
 	bits uint32
-}
-
-func (k *PrivateKeyRSA) finalize() {
-	bcrypt.DestroyKey(k.hkey)
 }
 
 func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error) {
@@ -125,7 +117,7 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error
 		return nil, err
 	}
 	k := &PrivateKeyRSA{hkey, uint32(N.bitLen())}
-	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
+	runtime.AddCleanup(k, destroyKey, k.hkey)
 	return k, nil
 }
 

--- a/cng/sha3.go
+++ b/cng/sha3.go
@@ -110,7 +110,7 @@ func newShake(id string, N, S []byte) *SHAKE {
 			panic(err)
 		}
 	}
-	runtime.SetFinalizer(h, (*SHAKE).finalize)
+	runtime.AddCleanup(h, destroyHash, h.ctx)
 	return h
 }
 
@@ -140,10 +140,6 @@ func NewCSHAKE128(N, S []byte) *SHAKE {
 // separation. When N and S are both empty, this is equivalent to NewSHAKE256.
 func NewCSHAKE256(N, S []byte) *SHAKE {
 	return newShake(bcrypt.CSHAKE256_ALGORITHM, N, S)
-}
-
-func (h *SHAKE) finalize() {
-	bcrypt.DestroyHash(h.ctx)
 }
 
 // Write absorbs more data into the XOF's state.


### PR DESCRIPTION
## Summary
- replace production resource finalizers with `runtime.AddCleanup` callbacks that retain only native CNG handles
- preserve shared ECDH handle ownership and cancel RC4 cleanup during `Reset`
- keep the hash allocation ceiling unchanged and add RC4 reset coverage

The PBKDF2 test-only finalizer remains because that test deliberately mutates the finalized object, which `runtime.AddCleanup` does not permit.

## Testing
- `GOTOOLCHAIN=go1.26.0 go test ./cng -run '^TestHashStructAllocations$' -count=10 -v`
- `GOTOOLCHAIN=go1.26.0 go test ./cng ./internal/... ./cmd/... -count=1`
- `git diff --check`